### PR TITLE
Phase 0: close auth gaps + add MIT/CC BY 4.0 licenses + sunset plan

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2025 mkpoli and LemonTV contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+NOTE: This MIT license covers the SOURCE CODE of LemonTV only. The esports
+DATASET served by LemonTV (players, teams, events, matches, statistics, and
+related records) is licensed separately — see LICENSE-DATA.md.

--- a/LICENSE-DATA.md
+++ b/LICENSE-DATA.md
@@ -1,0 +1,63 @@
+# LemonTV Data License
+
+The **LemonTV dataset** — the structured esports records compiled by LemonTV and
+its contributors, including players, teams, organizers, events, matches, maps,
+results, and derived statistics, whether accessed through the public API, a bulk
+data dump, or the database itself — is licensed under the
+
+**Creative Commons Attribution 4.0 International License (CC BY 4.0)**.
+
+Full legal text: https://creativecommons.org/licenses/by/4.0/legalcode
+Human-readable summary: https://creativecommons.org/licenses/by/4.0/
+
+CC BY 4.0 is chosen deliberately: unlike CC BY 3.0, the 4.0 version explicitly
+licenses the _sui generis database rights_ that apply in the EU/UK to a compiled
+dataset, while still requiring attribution back to LemonTV.
+
+## You are free to
+
+- **Share** — copy and redistribute the data in any medium or format.
+- **Adapt** — remix, transform, and build upon the data for any purpose, even
+  commercially.
+
+This is intended to give successor and sibling projects (e.g. StrinovaHub,
+Stringify) a solid, freely reusable foundation.
+
+## Under the following terms
+
+- **Attribution** — You must give appropriate credit to **LemonTV**, provide a
+  link to the source (https://lemontv.strinova.org or the project repository),
+  and indicate if changes were made. You may do so in any reasonable manner, but
+  not in any way that suggests LemonTV endorses you or your use.
+
+A suggested attribution string:
+
+> Data from LemonTV (https://lemontv.strinova.org), licensed under CC BY 4.0.
+
+## Scope — what this license does and does NOT cover
+
+This data license applies **only** to the factual dataset described above.
+
+It does **not** cover:
+
+- **The source code** of LemonTV — that is licensed separately under the MIT
+  License (see `LICENSE`).
+- **Trademarks, names, and logos** — "Strinova", team and organization names,
+  team/event logos, player avatars, and similar marks remain the property of
+  their respective owners. They are referenced under nominative/fair use and are
+  **not** relicensed here.
+- **Third-party content** — any images, media, or records that originate from a
+  third party and were not authored by LemonTV contributors remain under their
+  original rights and may not be covered by CC BY 4.0.
+
+## ⚠️ Provenance note (must be confirmed before relying on this license)
+
+This file states LemonTV's **intent** to license its own compiled data under
+CC BY 4.0. The grant is only valid for material LemonTV actually holds the rights
+to. Before treating any specific field or record as CC BY 4.0, confirm it was
+compiled/authored by LemonTV contributors rather than scraped or copied from a
+third-party source whose terms forbid redistribution. Where provenance is unclear
+or third-party-owned, that material is **excluded** from this grant.
+
+If you believe any data here infringes your rights, please open an issue on the
+repository so it can be reviewed and removed or re-attributed.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,18 @@ bun run db:dev:push
 ```bash
 bun run deploy
 ```
+
+## License
+
+LemonTV is split into two separately-licensed parts so that both the code and the
+data can be reused as openly as possible:
+
+- **Source code** — [MIT License](LICENSE).
+- **Esports dataset** (players, teams, events, matches, statistics, served via the
+  API / bulk dumps / database) — [Creative Commons Attribution 4.0 International
+  (CC BY 4.0)](LICENSE-DATA.md). Reuse freely with attribution to LemonTV.
+
+Trademarks, team/event logos, player avatars, and other third-party content are
+**not** covered by either license and remain the property of their respective
+owners. See [`LICENSE-DATA.md`](LICENSE-DATA.md) for the full scope and an
+important data-provenance note.

--- a/docs/SUNSET_PLAN.md
+++ b/docs/SUNSET_PLAN.md
@@ -1,0 +1,289 @@
+<!--
+  LemonTV Sunset Plan
+  Synthesized 2026-05-31 via a multi-agent codebase analysis.
+  This document is the roadmap for opening LemonTV up as the maintainer steps back.
+-->
+
+# Locked decisions (2026-05-31)
+
+These four architecture decisions are settled; the rest of this document elaborates them.
+
+| #   | Decision                          | Choice                                                                                                                        |
+| --- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| 1   | AI edits by authorized editors    | **Go live immediately, fully attributed** (editors are trusted; the proposal queue is for the open-edit _proposer_ tier only) |
+| 2   | MCP Personal Access Token ceiling | **Capped at `editor`** — no `admin`/user-role management via the AI path                                                      |
+| 3   | Dataset license                   | **CC BY 4.0** (code stays **MIT**)                                                                                            |
+| 4   | MCP topology                      | **In-process SvelteKit route** at `/api/mcp` (not a separate Worker)                                                          |
+
+Still open and owner-dependent: AI-edit policy for the _open-edit_ tier, auto-promotion thresholds, pagination style, exact public field set, and — critically — **data provenance** (whether any data is third-party-scraped, which constrains what CC BY 4.0 can actually cover). See "Open questions" at the end.
+
+# LemonTV Master Plan: Authorized MCP Server, Open Editing, and a CC-Licensed Public API
+
+## Executive summary
+
+LemonTV is a one-maintainer SvelteKit app whose esports dataset is worth opening up, but whose owner is stepping back from active development. The goal is to let the project **outlive hands-on maintenance**: authorized editors should manage data through AI, the wider community should be able to contribute wiki-style under monitoring, and successor projects (StrinovaHub, Stringify) should be able to reuse the data freely with credit.
+
+The good news, grounded in the codebase: roughly **80% of the machinery already exists**, just wired for a closed admin-only world. There is a clean, framework-agnostic data-access layer (`src/lib/server/data/*.ts`), a field-level audit trail (`edit_history`), a two-role RBAC (`checkPermissions`), JWT/JWKS SSO, and a pre-reserved `/api/public/` route prefix. The three pillars are not three separate systems — they are **three callers of one shared service layer, one audit log, and one zod contract**.
+
+The single most important sequencing decision: **the smallest safe path to "editing via AI" is the centerpiece, and it depends on a handful of pre-existing security gaps being closed first.** Everything else (open editing, public API, CC licensing) layers onto the same foundation.
+
+---
+
+## Current state (grounded in the real stack)
+
+| Concern          | Reality                                                                                   | Key files                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Framework        | SvelteKit 2 / Svelte 5 runes, Vite 7, Bun, Vercel adapter                                 | `svelte.config.js`, `vercel.json`                                                         |
+| Database         | Turso/libSQL (SQLite) via Drizzle ORM 0.45; dev uses `file:./dev.db`                      | `src/lib/server/db/index.ts`, `drizzle.config.ts`, `drizzle-dev.config.ts`                |
+| Schema           | ~47 tables, code-first, **no migrations** (push-based)                                    | `src/lib/server/db/schema.ts`, `src/lib/server/db/schemas/{auth,game,about,edit-history}` |
+| Read/write logic | Framework-agnostic typed functions, the canonical API                                     | `src/lib/server/data/{players,teams,events,matches,organizers,community,users,stats}.ts`  |
+| Audit trail      | Field-level `oldValue/newValue/editedBy/editedAt`, viewer at `/admin/edit-history`        | `src/lib/server/db/schemas/edit-history.ts`                                               |
+| Auth             | Custom Lucia-style sessions (Oslo + argon2), opaque tokens, HttpOnly cookie               | `src/lib/server/auth.ts`, `src/hooks.server.ts`                                           |
+| RBAC             | Exactly two roles: `admin`, `editor`; the one reusable gate                               | `src/lib/server/security/permission.ts`, `src/lib/server/db/sync.ts`                      |
+| SSO              | ES256 JWT issuance + JWKS discovery (jose)                                                | `src/routes/(user)/login/jwt/+server.ts`, `src/hooks.server.ts` (handleJWKS)              |
+| Validation       | zod used **only** for auth; domain writes use ad-hoc guards + `as` casts                  | `src/lib/validations/auth.ts`                                                             |
+| Public API       | `/api/public/` is **whitelisted in `src/hooks.server.ts:50`** but **no route exists yet** | (must be created)                                                                         |
+| Storage          | S3-compatible, 1h presigned URLs                                                          | `src/lib/server/storage.ts`                                                               |
+| Cost / abuse     | ~$1,200/yr; **no rate limiting, captcha, or caching anywhere** except JWKS                | `README.md`, `.github/FUNDING.yml`                                                        |
+| Licensing        | **No LICENSE file at all** — repo is all-rights-reserved by default                       | (must be created)                                                                         |
+
+### Three structural facts that shape everything
+
+1. **The data layer is split in maturity.** Players (`src/lib/server/data/players.ts`: `createPlayer` @960, `updatePlayer` @1151, `deletePlayer` @1453) and Teams (`src/lib/server/data/teams.ts`: @745/@933/@1236) have **clean, transactional, `(data, editedBy, tx?)` service functions that emit `edit_history`**. Events expose only `updateEventTeamPlayers` (@1181) and `updateEventCasters` (@1224); **event/match/organizer/game create/update/delete logic is trapped inline inside `+page.server.ts` actions** (`src/routes/(user)/admin/events/+page.server.ts`, `src/routes/(user)/admin/matches/[eventId]/+page.server.ts`). This single fact dictates v1 write scope everywhere.
+
+2. **Authorization lives only in the route layer.** `checkPermissions(locals, ['admin','editor'])` (`src/lib/server/security/permission.ts:7`) gates form actions. The service functions **trust their caller-supplied `editedBy` and perform no role check** (`createPlayer` @960 only inserts `edit_history`). Any non-route caller — MCP, scripts, proposal appliers — **must enforce authorization itself**.
+
+3. **Pre-existing security gaps will be amplified by any exposure.** These are prerequisites, not optional:
+   - `/admin/users/+page.server.ts` and `/admin/community/+page.server.ts` POST actions **do not re-check permissions inside the action** (rely on the load guard, which does not protect POSTs — a privilege-escalation gap).
+   - `POST /api/upload/+server.ts` and `GET /api/upload/[...key]/+server.ts` are **fully unauthenticated** (arbitrary S3 writes + signed-URL minting).
+   - `GET /api/events/[id]/history/+server.ts` is **unauthenticated and leaks editor emails**, unlike the role-gated players/teams history endpoints.
+
+---
+
+## Unifying architecture: one service layer, one audit log, one contract
+
+All three pillars converge on a shared spine. Build these once; every pillar reuses them.
+
+```
+                        ┌─────────────────────────────────────────────┐
+   AI client (PAT) ───► │  MCP endpoint  /api/mcp  (+server.ts)        │
+   Web UI (session) ──► │  Open-edit gateway  submitChange()          │ ─┐
+   Public reader ─────► │  Public API  /api/public/v1/* (read-only)   │  │
+                        └─────────────────────────────────────────────┘  │
+                                          │ enforce auth here (route layer)│
+                                          ▼                                │
+   ONE zod CONTRACT  ──►  validate inputs / project outputs (PII whitelist)│
+   src/lib/server/contract/*.ts                                           │
+                                          ▼                                │
+   ONE SERVICE LAYER  ──►  src/lib/server/data/*.ts  (data, editedBy, tx?)│
+                                          ▼                                │
+   ONE AUDIT LOG  ──►  edit_history (field diffs)  +  mcp_audit_log        │
+   src/lib/server/db/schemas/edit-history.ts        (denials/reads/limits) │◄┘
+```
+
+- **One service layer:** `src/lib/server/data/*.ts`. Reads back the public API and MCP read tools; writes back MCP write tools and the open-edit gateway. Where service functions are missing (events/matches/organizers/games), they **must be extracted from the inline actions** before those entities are writable by anything other than the admin UI.
+- **One audit log:** `edit_history` records every successful field-level change keyed by `editedBy`. A new `mcp_audit_log` table (must be created) records what `edit_history` cannot — reads, denials, validation failures, rate-limit hits — keyed by token. AI-origin edits get a `_source='mcp:<tool>'` marker row in `edit_history` so the existing `/admin/edit-history` viewer distinguishes them.
+- **One typed contract:** a new `src/lib/server/contract/*.ts` zod package (must be created; zod v4 is already a dependency per `src/lib/validations/auth.ts`). The same schemas drive MCP tool `inputSchema`, MCP/REST response projection (the PII whitelist), and the public OpenAPI doc — so the surfaces **cannot drift**.
+
+The single rule that keeps this safe: **no caller touches Drizzle or a service function directly without passing through the contract + an authorization check.** Pushing `checkPermissions` down into the data layer is the cleaner long-term fix but touches every existing form-action caller; for v1 the boundary is enforced at each entry point.
+
+---
+
+## Pillar 1 — Authorized MCP server (centerpiece)
+
+**Goal:** authorized editors manage data via AI (Claude Desktop/Code) through a single bearer token, with every AI edit attributed to one real human and fully auditable.
+
+### Shape
+
+An **in-process** MCP server mounted as a SvelteKit route at **`src/routes/api/mcp/+server.ts`** (must be created), implementing the Streamable HTTP transport via `@modelcontextprotocol/sdk` (a new dependency — greenfield). It calls `src/lib/server/data/*.ts` directly with the shared Drizzle `db`, so reads and writes get identical normalized output and free `edit_history` attribution.
+
+**Critical placement:** mounted under `/api/mcp`, **NOT** under `/api/public/`. The `/api/public/` prefix (`src/hooks.server.ts:50`) sets `locals.user=null` and returns before any auth — a write surface there would be unauthenticated by default. `/api/` is already excluded from Paraglide i18n (`src/hooks.server.ts:29`), so `/api/mcp` needs no pipeline change and authenticates itself from the `Authorization` header.
+
+### Centerpiece decision: identity model
+
+**Decision:** a new revocable, scoped, hashed **Personal Access Token** (`mcp_token` table, must be created), minted by an editor from their own profile, bound to one real `user.id` and that user's roles.
+
+It reuses the exact session primitive: `generateSessionToken` (`src/lib/server/auth.ts:57`, 18 random bytes → base64url) + `sha256` + `encodeHexLowerCase` (`auth.ts:64,84`), with a `lemon_pat_` display prefix. Plaintext shown once at creation; only the hash is stored.
+
+| Alternative                                 | Why rejected                                                                                                                                                                                                                                       |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reuse the existing ES256 SSO JWT for writes | Delivered via `?token=` query param (`login/jwt/+server.ts:66`, leaks to logs); roles frozen at issuance; **7-day lifetime, no revocation list** — a de-authorized editor keeps write access for up to a week. Unsafe for an automated write path. |
+| Full OAuth 2.1 + PKCE (MCP spec)            | Auth server + client registration + consent UI = weeks of work for a one-dev fan project.                                                                                                                                                          |
+| Reuse session cookies                       | HttpOnly cookies are not ergonomic for headless AI clients.                                                                                                                                                                                        |
+
+The JWT/JWKS path (`src/hooks.server.ts` handleJWKS) is **kept only as an optional read-only bearer**, never for writes.
+
+### What to build vs reuse
+
+| Component                                                                         | Build / Reuse                      | Files                                                                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mcp_token` schema (scoped, revocable, hashed PAT)                                | **Build**                          | `src/lib/server/db/schemas/auth/mcp-token.ts`; re-export via `…/auth/index.ts`, `…/schemas/index.ts`                                                                                                                                                                         |
+| `mcp_audit_log` schema (reads/denials/rate-limit)                                 | **Build**                          | `src/lib/server/db/schemas/auth/mcp-audit-log.ts`                                                                                                                                                                                                                            |
+| `mcp_rate_limit` (token-bucket counters)                                          | **Build**                          | `src/lib/server/db/schemas/auth/mcp-rate-limit.ts`                                                                                                                                                                                                                           |
+| PAT service (`createMcpToken`/`validateMcpToken`/`revokeMcpToken`/`listMcpToken`) | **Build**, mirroring session funcs | `src/lib/server/security/mcp-token.ts` (reuses `auth.ts:57,64`, role query `auth.ts:107-110`)                                                                                                                                                                                |
+| MCP endpoint + transport                                                          | **Build**                          | `src/routes/api/mcp/+server.ts`, `src/lib/server/mcp/server.ts`, `src/lib/server/mcp/identity.ts`                                                                                                                                                                            |
+| MCP guard (role + scope + rate limit, deny-by-default)                            | **Build**                          | `src/lib/server/mcp/guard.ts` (replicates `permission.ts:7` semantics)                                                                                                                                                                                                       |
+| Read tools (PII-projected)                                                        | **Build wrappers**, reuse getters  | `src/lib/server/mcp/tools/read.ts` over `getPlayers/getPlayer/getPlayerStats/getPlayerDetailedMatches`, `getTeams/getTeam/getTeamStatistics`, `getEssentialEvents/getEvent`, `getMatch` (first programmatic surface — no HTTP endpoint exists), `getOrganizers/getOrganizer` |
+| Write tools v1 (players, teams, event roster/casters)                             | **Build wrappers**, reuse services | `src/lib/server/mcp/tools/write.ts` → `createPlayer/updatePlayer/deletePlayer`, `createTeam/updateTeam/deleteTeam`, `updateEventTeamPlayers/updateEventCasters`                                                                                                              |
+| zod contract package                                                              | **Build**                          | `src/lib/server/contract/{players,teams,events,index}.ts`                                                                                                                                                                                                                    |
+| Rate limiter (token-bucket per PAT)                                               | **Build**                          | `src/lib/server/security/rate-limit.ts`                                                                                                                                                                                                                                      |
+| PAT dashboard                                                                     | **Build**                          | `src/routes/(user)/profile/mcp-tokens/+page.{server.ts,svelte}`                                                                                                                                                                                                              |
+| Moderation/audit viewer                                                           | **Build**                          | `src/routes/(user)/admin/mcp-log/+page.server.ts`                                                                                                                                                                                                                            |
+
+### Key decisions
+
+- **Re-check authorization inside every write tool.** A single mandatory `guard.ts` runs before dispatch: (1) `checkPermissions`-equivalent on the PAT's resolved roles (`editor`|`admin`); (2) per-token scope check (least privilege); (3) deny all user/role management tools (mirroring `/admin/users` being admin-only); (4) token-bucket rate limit. On failure, write a `denied` row to `mcp_audit_log` and return a JSON-RPC error. _Rejected alternative:_ pushing `checkPermissions` into the data layer — correct long-term, but touches every form-action caller; out of scope for v1.
+- **Editors can only mint tokens scoped to roles they already hold.** An editor cannot create an admin token. Cap discussion is an open question.
+- **Tag AI edits.** Successful writes get a `_source='mcp:<tool>'` marker in `edit_history` so `/admin/edit-history` distinguishes AI from human-UI edits.
+- **v1 write coverage = players + teams + event roster/casters only**, because those are the only entities with clean service functions. POST-emulating form actions is **explicitly rejected** (brittle, bypasses validation, produces weak/no `edit_history`).
+
+---
+
+## Pillar 2 — Open editing + moderation (wiki-style)
+
+**Goal:** let logged-in non-editors contribute, under monitoring, **without increasing the owner's ongoing workload.**
+
+### Core model
+
+Add exactly **one new tier**, **one new table**, and **one write gateway**.
+
+- **Tiers** (only the proposer tier is new; it needs no DB role row — it is simply "logged-in but lacks `editor`/`admin`"):
+
+  | Tier                 | Who                             | Capability                                             |
+  | -------------------- | ------------------------------- | ------------------------------------------------------ |
+  | Anonymous            | logged-out                      | read-only                                              |
+  | **Proposer** _(new)_ | logged-in, no editor/admin role | submissions **queue** as proposals                     |
+  | Trusted editor       | existing `editor`               | **direct writes go live**; can review proposals        |
+  | Admin                | existing `admin`                | everything incl. user/role mgmt, bulk revert, blocking |
+
+- **`change_proposal` table** (must be created, modeled on `edit-history.ts`): `tableName`, `recordId` (nullable for creates), `operation`, `payload` (JSON = the exact argument object the service functions accept), `proposedBy`, `status`, `reviewedBy`, `reviewNote`, `source` (`web`|`mcp`), timestamps. **A proposal is a deferred service call:** approval = call `createPlayer/updatePlayer/…` with `editedBy = the original proposer` inside the reviewer's transaction, so attribution stays correct and there is **no second write engine**.
+
+- **One write gateway** `submitChange(input, actor)` (`src/lib/server/data/changes.ts`, must be created): resolves the actor's tier; trusted/admin → validate + call the service directly (live); proposer → validate + insert a pending `change_proposal`. The MCP server, the web forms, and the proposal applier **all funnel through this one gateway** — so nothing can bypass moderation, and `edit_history` is guaranteed.
+
+### Decisions
+
+| Decision                                                                   | Rationale                                                                                                          | Rejected                                                                                                              |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Queue only for proposers; keep direct-write for editors                    | Owner is winding down — review load must fall **only** on untrusted/new contributors (the "autoconfirmed" pattern) | Everyone-proposes (too much reviewer load); everyone-writes + post-hoc patrol (unsustainable, exposes live vandalism) |
+| Proposals store service-function arguments, applied via the same functions | Zero duplication of write logic or audit instrumentation                                                           | Shadow per-table pending rows; raw SQL (unsafe)                                                                       |
+| Add soft-delete `deletedAt` to player/team/event                           | Deletion vandalism is otherwise only recoverable by fragile `edit_history` replay                                  | Pure replay (brittle for sparsely-audited inline entities)                                                            |
+| Auto-promote proposers to `editor` after K approved edits                  | Keeps the maintainer's steady-state review load near zero                                                          | Manual-only promotion (more owner work)                                                                               |
+
+### Build vs reuse
+
+- **Reuse:** `checkPermissions`, the players/teams service functions, `edit_history`, the existing diff rendering in `src/routes/(user)/admin/EditHistory.svelte`, the JWT/JWKS for MCP-origin proposals.
+- **Build:** the `proposer` tier resolver; `change_proposal` table; `submitChange` gateway; `applyProposal`/`rejectProposal`; **revert** (`revertEdit`/`revertRecordToTimestamp` applying old `edit_history` values via service updates — logged as new edits, never deleting history); soft-delete columns; a minimal moderation queue at `src/routes/(user)/admin/moderation/` (approve/reject/bulk/block/promote, each with **inner** `checkPermissions`); per-entity zod schemas; and the anti-abuse layer (rate limiting in `src/hooks.server.ts`, captcha on register + new-account proposals).
+- **Must refactor first:** events/matches/organizers inline write logic into service functions before those entities are proposable. Until then they stay editor/admin-only.
+
+---
+
+## Pillar 3 — Public read API + CC licensing
+
+**Goal:** make the dataset publicly reusable and legally clear so successor projects can build on it with credit.
+
+### API shape
+
+A **versioned, read-only** JSON API at **`/api/public/v1/*`** — the pre-blessed mount point (`src/hooks.server.ts:50` already whitelists `/api/public/` from auth; `:29` excludes `/api/` from i18n). Each `+server.ts` GET handler (must be created) calls the data-layer getter in-process, **projects through a zod response schema (the PII whitelist)**, sets `Cache-Control`, and returns `json()`.
+
+Resources (slug- or id-addressable, matching `getPlayer(keyword)`/`getTeam(slug)`/`getEvent(idOrSlug)` ergonomics): `players[/{slug}[/stats|/matches]]`, `teams[/{slug}[/matches]]`, `events[/{idOrSlug}]`, `matches/{id}`, `organizers[/{slug}]`, `community/discord-servers`, `meta/maps`, `meta/characters`, plus `openapi.json`, `dump`, and `license`.
+
+### Decisions
+
+| Decision                                                                                                                    | Rationale                                                                                                                                                                                                                                           | Rejected                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Mount at `/api/public/v1/*`, in-process over the data layer                                                                 | Zero pipeline change; identical normalized output; path versioning is cache-friendly                                                                                                                                                                | Separate Worker (splits topology); tRPC/GraphQL (not in stack); reusing scattered `/api/events/[id]/*` (raw rows, leak emails, unversioned)                  |
+| **zod = single source of truth** for response schemas → OpenAPI 3.1 + MCP tool schemas                                      | zod v4's `z.toJSONSchema()` generates the OpenAPI doc; the MCP server reads the same schemas, so **REST and MCP cannot drift**                                                                                                                      | Hand-authored OpenAPI (drifts); `drizzle-zod` (mirrors DB columns incl. PII)                                                                                 |
+| **Explicit field-whitelist** — never expose `user.email`, `user.id` linkage, `passwordHash`, edit-history editor identities | Data-layer App objects include `user?: User` and several endpoints join `user.email`; verbatim return leaks PII                                                                                                                                     | Trusting the data layer's shape                                                                                                                              |
+| **CC BY 4.0** for the dataset; separate code license (MIT vs AGPL TBD)                                                      | Facts aren't copyrightable in the US, but EU/UK **sui generis database right** + compilation copyright do apply; CC BY 4.0 explicitly licenses database rights (3.0 does not) and requires attribution to LemonTV — serving the owner's credit goal | CC0 (no attribution — documented fallback); **CC BY-SA (viral share-alike deters commercial successors — not recommended)**; ODbL (heavier, less understood) |
+| Caching-first cost control + token-bucket on uncached routes                                                                | Owner cares about ~$1,200/yr; Turso bills per row-read; CDN turns repeat reads into zero Turso reads                                                                                                                                                | Redis/Upstash limiter (overkill); no caching (multiplies cost under scrapers)                                                                                |
+| Nightly bulk dump (JSON + JSON-Lines + SQL) under the same license                                                          | Cheaper than full-table scans; canonical CC artifact for mirroring                                                                                                                                                                                  | API-only (pushes cost to live queries)                                                                                                                       |
+
+### Build vs reuse
+
+- **Reuse:** all data-layer getters; `processImageURL` (`storage.ts`) for image resolution; the JWKS `Cache-Control` pattern (`hooks.server.ts:108`); the existing `db:prod:dump` SQL dump.
+- **Build:** public zod schemas (`src/lib/server/api/public/schemas/*`), OpenAPI generator + `/openapi.json` route, pagination/serialization helpers, per-IP rate limiter, bulk-dump publisher (`scripts/publish-public-dump.ts` + a Vercel cron in `vercel.json`), and the licensing files (`LICENSE`, `LICENSE-DATA.md`, README data-vs-code section, `/api/public/v1/license`, `Link: rel="license"` header).
+- **Image caveat:** presigned URLs expire in 1h (`storage.ts:42`); cache TTL on image-bearing routes **must be < 1h**, or return stable keys + a documented resolver.
+
+---
+
+## Phased roadmap (biased to the smallest safe path to editing-via-AI)
+
+The ordering principle: **close the gaps the MCP RBAC would inherit, then ship the MCP centerpiece on players+teams, then layer open editing and the public API on the same spine.** Open editing and the public API both depend on Phase 0 too — doing it once unblocks all three.
+
+### Phase 0 — Security + legal prerequisites (must precede _any_ exposure)
+
+- Add inner `checkPermissions` to every POST action in `/admin/users/+page.server.ts` and `/admin/community/+page.server.ts`.
+- Gate `POST /api/upload` and `GET /api/upload/[...key]` behind `checkPermissions(['admin','editor'])` + file type/size validation.
+- Role-gate `GET /api/events/[id]/history` (stop leaking editor emails).
+- Confirm `seed()` is strictly dev-gated (`src/hooks.server.ts:13`, behind `dev`) so no shared/test write path triggers a destructive reseed.
+- Add a CODE `LICENSE` and a `LICENSE-DATA.md` (CC BY 4.0) + README data-vs-code/provenance note. _(Hard blocker for the public-API framing; cheap to do now.)_
+
+### Phase 1 — MCP foundation (the centerpiece, smallest safe AI-editing path)
+
+- Add `mcp_token`, `mcp_audit_log`, `mcp_rate_limit` schemas; `drizzle-kit push` to dev then prod (additive, low-risk).
+- Implement `src/lib/server/security/mcp-token.ts` + unit test beside `permission.test.ts`.
+- Build the zod contract for players + teams (`src/lib/server/contract/*`).
+- Build `/profile/mcp-tokens` dashboard (one-time plaintext reveal, scopes ≤ own roles, expiry, revoke).
+
+### Phase 2 — MCP server + read tools
+
+- Add `@modelcontextprotocol/sdk`; create `src/routes/api/mcp/+server.ts` (confirm **not** under `/api/public/`).
+- Implement the tool registry + read tools over all getters, with the contract PII whitelist applied to every response.
+
+### Phase 3 — MCP write tools (players + teams + event roster/casters)
+
+- Implement `guard.ts` (role + scope + rate limit, deny-by-default) and `tools/write.ts`.
+- Wire the token-bucket limiter (fail-safe deny). Verify `edit_history` rows + `_source='mcp:<tool>'` markers appear.
+- Build `/admin/mcp-log` viewer with one-click revoke. **At this point, authorized editing via AI is live, safe, and auditable.**
+
+### Phase 4 — Public read API + CC licensing
+
+- Build public zod schemas, OpenAPI generator, pagination + cache helpers, and the `/api/public/v1/*` read endpoints (cached, field-whitelisted, paginated).
+- Serve `/openapi.json` and `/license`; add the `Link: rel="license"` header and per-IP limiter on uncached routes.
+- Ship the nightly bulk-dump publisher + cron.
+
+### Phase 5 — Open editing + moderation
+
+- Build the `submitChange` gateway and refactor admin players/teams actions to route through it (behavior identical for editors).
+- Add `change_proposal`, the proposer tier, `applyProposal`/`rejectProposal`, and the `/admin/moderation` queue.
+- Add revert + soft-delete (`deletedAt`) + rate limiting in `hooks.server.ts` + captcha on register/new-account proposals + auto-promotion.
+
+### Phase 6 — Write-coverage expansion (follow-up)
+
+- Extract `createEvent/updateEvent/deleteEvent` (and matches/stages/games, organizers) from the inline `+page.server.ts` actions into `(data, editedBy, tx?)` service functions; repoint the form actions.
+- Add contract write schemas and register `events.*`/`matches.*`/`organizers.*`/`games.*` MCP tools and proposal support behind the same guard — no new auth/transport work.
+- Optional: optimistic-concurrency (`updatedAt` compare-and-swap) on high-contention entities before heavy concurrent AI use.
+
+---
+
+## Risks & abuse surface
+
+- **Service functions do no authorization** (`createPlayer` @960 trusts caller `editedBy`). If the guard/gateway is bypassed, an under-privileged token/identity gains full editor write access. _Mitigation:_ one mandatory guard, deny-by-default registry, code review that no tool/caller hits a service without the guard.
+- **No rate limiting / captcha / caching exists today** (except JWKS). Any public, open-edit, or MCP surface inherits this. _Mitigation:_ land anti-abuse in the **same phase** as each surface, never after; bulk dump as the pressure-relief valve for heavy consumers.
+- **PII leakage** is the single most important correctness boundary. Data-layer readers join `user.email`/`userId`. _Mitigation:_ enforce the contract read schema on **every** response centrally; never return raw objects; cover with tests.
+- **Pre-existing auth gaps** (`/admin/users`, `/admin/community`, `/api/upload`, `/api/events/[id]/history`) become privilege-escalation/cost-abuse vectors once anything is advertised. Phase 0 fixes are non-negotiable.
+- **7-day non-revocable JWTs** make role revocation/blocking ineffective for that token until expiry — hence PATs (instant revoke) for the write path.
+- **No optimistic concurrency** anywhere: AI + human editing the same record silently last-write-wins; AI frequency raises collision odds.
+- **No soft-delete today**: deletion vandalism is hard to revert, especially for sparsely-audited inline entities.
+- **Stats staleness:** `player_stats`/`player_character_stats` refresh only via the 02:00 UTC cron (`/api/cron/recalculate-player-stats`); stats endpoints/tools must flag a "last recalculated" timestamp.
+- **Push-based schema, no migrations:** new `mcp_*`/`change_proposal`/soft-delete columns are additive (low risk) but there is no rollback path — coordinate with `db:prod:dump` backup.
+- **Image URL expiry (1h):** caching image-bearing responses longer than the presign window serves dead links.
+- **No LICENSE blocks the "open" framing** entirely until Phase 0; and **data provenance** (any scraped third-party data?) may constrain what can be CC-licensed at all.
+- **Cross-server casing** (`event.server` `'calabiyau'|'strinova'` vs `game_account.server` `'CalabiYau'|'Strinova'`) and `game_player_score.accountId` having no FK must be normalized in the contract.
+
+---
+
+## Open questions for the owner
+
+**Identity & scope (MCP)**
+
+1. May an MCP PAT ever carry the `admin` scope, or is it capped at `editor` to keep user/role management out of the AI path?
+2. Confirm token defaults: prefix `lemon_pat_`, default expiry (e.g. 90 days), and whether non-expiring tokens are allowed for trusted long-running clients.
+3. Should `mcp_audit_log` redact tool args by default (privacy) or store full args (forensic moderation)?
+4. Rate-limit storage: Turso-backed counters (durable, costs reads) or in-memory per-instance (cheaper, less accurate under Vercel concurrency)?
+
+**Editing policy (open-edit + MCP)** 5. Should AI-originated edits go live immediately (current direct-write model, attributed) or pass through the proposal queue? Equivalently: does an AI act as a per-user identity whose edits **queue** (human-in-the-loop), or as a granted `editor` (live writes)? _This is the biggest safety lever._ 6. Which entities are open-editable by proposers in v1 — players/teams only, or also curation-sensitive `event_team` status/results/casters? 7. Auto-promotion: after how many approved proposals (over what window) does a proposer become trusted, and automatic or admin-confirmed? 8. Is there a `trusted` role between proposer and `editor`, or is `editor` reused as trusted-editor (lowest effort)?
+
+**Public API & licensing** 9. Final dataset license: **CC BY 4.0** (recommended, attribution) vs **CC0** (max reuse) vs CC BY-SA (not recommended)? And the separate code license (MIT vs AGPL-3.0)? 10. **Data provenance:** is any esports data scraped from third parties? This affects whether CC can be granted for those fields at all. 11. Pagination style for v1: page/limit (simple) or opaque cursor (robust under concurrent edits)? 12. Exact public field set — expose `game_account.accountId` and any player↔user linkage at all? 13. Should the bulk dump be the **primary** recommended path for heavy/AI consumers, with the live API rate-limited harder?
+
+**Operational confirmations** 14. Confirm the Phase 0 fixes (`/admin/users` + `/admin/community` inner checks, unauthenticated `/api/upload`, unauthenticated `/api/events/[id]/history`) are bugs to fix, not intentional internal flows. 15. In-process SvelteKit `/api/mcp` (recommended) vs a separate Cloudflare Worker (splits topology, requires HTTP callbacks)? 16. Is adding soft-delete (`deletedAt`) acceptable given push-only schema changes touch read queries across the data layer?

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
+	"license": "MIT",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -54,19 +54,19 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 		'/js/'
 	];
 
+	// Static-asset extensions are treated as public — but NOT under /api/,
+	// where a key ending in an image extension (e.g. /api/upload/<key>.png)
+	// is an authenticated API call, not a static file. Letting the extension
+	// shortcut apply there would null out locals.user and break per-route
+	// authorization checks for signed-in admins/editors.
+	const path = event.url.pathname;
+	const staticAssetExtensions = ['.css', '.js', '.png', '.jpg', '.jpeg', '.svg', '.ico'];
+	const isStaticAsset =
+		!path.startsWith('/api/') && staticAssetExtensions.some((ext) => path.endsWith(ext));
+
 	// Check if this is a public route
-	const isPublicRoute = publicRoutes.some(
-		(route) =>
-			event.url.pathname === route ||
-			event.url.pathname.startsWith(route) ||
-			event.url.pathname.endsWith('.css') ||
-			event.url.pathname.endsWith('.js') ||
-			event.url.pathname.endsWith('.png') ||
-			event.url.pathname.endsWith('.jpg') ||
-			event.url.pathname.endsWith('.jpeg') ||
-			event.url.pathname.endsWith('.svg') ||
-			event.url.pathname.endsWith('.ico')
-	);
+	const isPublicRoute =
+		isStaticAsset || publicRoutes.some((route) => path === route || path.startsWith(route));
 
 	// Skip authentication for public routes
 	if (isPublicRoute) {

--- a/src/routes/(user)/admin/community/+page.server.ts
+++ b/src/routes/(user)/admin/community/+page.server.ts
@@ -15,6 +15,7 @@ import {
 import { randomUUID } from 'node:crypto';
 import type { PageServerLoad, Actions } from './$types';
 import type { DiscordServer, CommunityTag } from '$lib/server/db/schemas/about/community';
+import { checkPermissions } from '$lib/server/security/permission';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
 	const user = locals.user;
@@ -34,7 +35,12 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 };
 
 export const actions: Actions = {
-	create: async ({ request }) => {
+	create: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const title = formData.get('title') as string;
 		const url = formData.get('url') as string;
@@ -71,7 +77,12 @@ export const actions: Actions = {
 		};
 	},
 
-	update: async ({ request }) => {
+	update: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
 		const title = formData.get('title') as string;
@@ -114,7 +125,12 @@ export const actions: Actions = {
 		};
 	},
 
-	delete: async ({ request }) => {
+	delete: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
 
@@ -134,7 +150,12 @@ export const actions: Actions = {
 		};
 	},
 
-	tag: async ({ request }) => {
+	tag: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
 		const category = formData.get('category') as string;
@@ -165,7 +186,12 @@ export const actions: Actions = {
 		};
 	},
 
-	deleteTag: async ({ request }) => {
+	deleteTag: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
 
@@ -179,7 +205,12 @@ export const actions: Actions = {
 		};
 	},
 
-	addTagToServer: async ({ request }) => {
+	addTagToServer: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const serverId = formData.get('serverId') as string;
 		const tagId = formData.get('tagId') as string;
@@ -194,7 +225,12 @@ export const actions: Actions = {
 		};
 	},
 
-	removeTagFromServer: async ({ request }) => {
+	removeTagFromServer: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin', 'editor']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const serverId = formData.get('serverId') as string;
 		const tagId = formData.get('tagId') as string;

--- a/src/routes/(user)/admin/users/+page.server.ts
+++ b/src/routes/(user)/admin/users/+page.server.ts
@@ -1,8 +1,9 @@
-import { redirect } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { and, eq } from 'drizzle-orm';
+import { checkPermissions } from '$lib/server/security/permission';
 
 export const load: PageServerLoad = async (event) => {
 	if (!event.locals.user || !event.locals.user.roles.includes('admin')) {
@@ -22,7 +23,12 @@ export const load: PageServerLoad = async (event) => {
 };
 
 export const actions: Actions = {
-	updateRole: async ({ request }) => {
+	updateRole: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const userId = formData.get('userId') as string;
 		const roleId = formData.get('roleId') as string;
@@ -50,7 +56,12 @@ export const actions: Actions = {
 		}
 	},
 
-	createRole: async ({ request }) => {
+	createRole: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const name = formData.get('name') as string;
 
@@ -70,7 +81,12 @@ export const actions: Actions = {
 		}
 	},
 
-	updateRoleName: async ({ request }) => {
+	updateRoleName: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
 		const name = formData.get('name') as string;
@@ -88,7 +104,12 @@ export const actions: Actions = {
 		}
 	},
 
-	deleteRole: async ({ request }) => {
+	deleteRole: async ({ request, locals }) => {
+		const permission = checkPermissions(locals, ['admin']);
+		if (permission.status === 'error') {
+			return fail(permission.statusCode, { error: permission.error });
+		}
+
 		const formData = await request.formData();
 		const id = formData.get('id') as string;
 

--- a/src/routes/api/events/[id]/history/+server.ts
+++ b/src/routes/api/events/[id]/history/+server.ts
@@ -3,8 +3,14 @@ import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { eq, and, inArray } from 'drizzle-orm';
+import { checkPermissions } from '$lib/server/security/permission';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
+	const permission = checkPermissions(locals, ['admin', 'editor']);
+	if (permission.status === 'error') {
+		return json({ error: permission.error }, { status: permission.statusCode });
+	}
+
 	const { id } = params;
 
 	try {

--- a/src/routes/api/upload/+server.ts
+++ b/src/routes/api/upload/+server.ts
@@ -1,13 +1,39 @@
 import { json } from '@sveltejs/kit';
 import { uploadImage } from '$lib/server/storage';
+import { checkPermissions } from '$lib/server/security/permission';
 
-export async function POST({ request }) {
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_MIME_TYPES = new Set([
+	'image/png',
+	'image/jpeg',
+	'image/webp',
+	'image/gif',
+	'image/avif'
+]);
+
+export async function POST({ request, locals }) {
+	const permission = checkPermissions(locals, ['admin', 'editor']);
+	if (permission.status === 'error') {
+		return json({ error: permission.error }, { status: permission.statusCode });
+	}
+
 	const formData = await request.formData();
 	const file = formData.get('file') as File;
 	const prefix = (formData.get('prefix') as string) || 'uploads';
 
 	if (!file) {
 		return json({ error: 'No file provided' }, { status: 400 });
+	}
+
+	if (!ALLOWED_MIME_TYPES.has(file.type)) {
+		return json({ error: `Unsupported file type: ${file.type || 'unknown'}` }, { status: 415 });
+	}
+
+	if (file.size > MAX_UPLOAD_BYTES) {
+		return json(
+			{ error: `File too large (max ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB)` },
+			{ status: 413 }
+		);
 	}
 
 	try {

--- a/src/routes/api/upload/[...key]/+server.ts
+++ b/src/routes/api/upload/[...key]/+server.ts
@@ -1,7 +1,13 @@
 import { json } from '@sveltejs/kit';
 import { getSignedImageUrl } from '$lib/server/storage';
+import { checkPermissions } from '$lib/server/security/permission';
 
-export async function GET({ params }) {
+export async function GET({ params, locals }) {
+	const permission = checkPermissions(locals, ['admin', 'editor']);
+	if (permission.status === 'error') {
+		return json({ error: permission.error }, { status: permission.statusCode });
+	}
+
 	const { key } = params;
 
 	if (!key) {


### PR DESCRIPTION
Phase 0 of the **LemonTV sunset plan** — the prerequisites that must land before opening LemonTV up (authorized MCP server, wiki-style open editing, public API + CC licensing). See `docs/SUNSET_PLAN.md` for the full roadmap and the four locked architecture decisions.

## 🔒 Security fixes (exploitable today)

These were found by reading the actual code; each is verified, and gating them does **not** break any public page (only the admin `ImageUpload` component and admin pages consume the affected routes).

| Gap | Before | After |
|---|---|---|
| `POST /api/upload` | **fully unauthenticated** — arbitrary S3 writes | `admin`/`editor` only + MIME-type + 5 MB size validation |
| `GET /api/upload/[...key]` | **fully unauthenticated** — mints signed URLs for any key | `admin`/`editor` only |
| `/admin/users` actions (`updateRole`, `createRole`, `updateRoleName`, `deleteRole`) | **no permission check** — load guard doesn't protect POSTs, so anyone could grant themselves **admin** | inner `checkPermissions(['admin'])` on every action |
| `/admin/community` actions (7) | **no permission check** | inner `checkPermissions(['admin','editor'])` on every action |
| `GET /api/events/[id]/history` | **unauthenticated, leaks editor emails** | `admin`/`editor` only (matches players/teams siblings) |

## 📜 Licensing (the repo had **no LICENSE file** = all-rights-reserved)

- **`LICENSE`** — MIT, for the source code.
- **`LICENSE-DATA.md`** — CC BY 4.0 for the esports dataset, with explicit scope (excludes code, trademarks, logos, third-party content) and a provenance caveat.
- README License section + `package.json` `"license": "MIT"`.

## ⚠️ Two choices to confirm before merge

1. **Code license** = MIT and **data license** = CC BY 4.0 are sensible "open + reusable with credit" defaults, but they're consequential. Switch MIT→AGPL or CC BY→CC0 here if preferred.
2. **Data provenance** — CC BY 4.0 only validly covers data LemonTV authored. Confirm nothing is third-party-scraped before relying on the grant (noted in `LICENSE-DATA.md`).

## ✅ Verification
- `bun run check` → **0 errors** (108 pre-existing warnings, none in changed files)
- `bun test src/lib/server/security` → **14 pass / 0 fail**
- Audited all `/api/**` endpoints: no other unauthenticated write/PII routes (`video-metadata` only hits hardcoded providers — no SSRF; cron is `CRON_SECRET`-gated).

## Not in scope (follow-ups noted in the plan)
- Rate limiting / caching (incl. unauthenticated YouTube-quota use in `video-metadata`).
- `prefix`/filename sanitization on uploads (now limited to trusted editors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)