### PR TITLE
Phase 2/3: MCP server endpoint + event read/write tools

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,130 @@
+# LemonTV MCP Server
+
+The authorized MCP server lets editors manage LemonTV data from an AI client
+(Claude Desktop, Claude Code, etc.). Every action is performed **as the token
+owner** and recorded in `edit_history`, so AI-assisted edits are attributable
+and auditable just like edits made through the admin UI.
+
+## Endpoint & authentication
+
+- **Endpoint:** `POST https://lemontv.win/api/mcp` (JSON-RPC 2.0, MCP protocol `2024-11-05`)
+- **Auth:** a Personal Access Token (PAT) in the `Authorization: Bearer …` header.
+
+Mint a token at **Profile → MCP Tokens** (`/profile/mcp-tokens`):
+
+- **Read** tokens can call read tools (`list_events`, `get_event`).
+- **Write** tokens can additionally call write tools (`create_event`). A write
+  token only works while its owner still holds the `editor` or `admin` role — if
+  the role is removed, the token silently drops to read-only.
+
+The plaintext token (`lemon_pat_…`) is shown **once** at creation. Store it like
+a password; it can be revoked any time from the same page.
+
+## Connecting from Claude Code
+
+```bash
+claude mcp add --transport http lemontv https://lemontv.win/api/mcp \
+  --header "Authorization: Bearer lemon_pat_YOUR_TOKEN_HERE"
+```
+
+Claude Desktop and other clients: point a Streamable-HTTP MCP server at the
+endpoint above and set the same `Authorization` header.
+
+## Tools
+
+| Tool           | Scope     | Purpose                                                           |
+| -------------- | --------- | ----------------------------------------------------------------- |
+| `list_events`  | read      | List tournaments/events (newest first); optional `status` filter. |
+| `get_event`    | read      | Fetch one event by `idOrSlug`.                                    |
+| `create_event` | **write** | Create a new tournament/event. Returns the new id.                |
+
+`create_event` arguments: `name`, `slug`, `server` (`calabiyau`\|`strinova`),
+`format` (`lan`\|`online`\|`hybrid`), `region`, `status`
+(`upcoming`\|`live`\|`finished`\|`cancelled`\|`postponed`), `date`
+(`YYYY-MM-DD` or `YYYY-MM-DD/YYYY-MM-DD`), `image` (required — a placeholder URL
+is fine), plus optional `official`, `capacity`, `organizerIds`, `websites`.
+Teams, results, and casters are added separately (admin UI for now).
+
+## Example: adding a tournament
+
+A `tools/call` request to create an event:
+
+```json
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"method": "tools/call",
+	"params": {
+		"name": "create_event",
+		"arguments": {
+			"name": "Origami Cup 4",
+			"slug": "origami-cup-4",
+			"server": "strinova",
+			"format": "online",
+			"region": "Global",
+			"status": "finished",
+			"date": "2026-03-07/2026-03-15",
+			"image": "https://picsum.photos/seed/origami-cup-4/300/200",
+			"official": false,
+			"capacity": 8,
+			"websites": [{ "url": "https://www.twitch.tv/origamicup", "label": "Twitch" }]
+		}
+	}
+}
+```
+
+## Prepared backfill (March–May 2026 gap)
+
+LemonTV's event list currently stops around February 2026. These two community
+tournaments are missing and ready to add via `create_event`. **Fields marked
+`TODO` are unverified** — confirm against the organizer's bracket/Discord before
+or shortly after creating, since the public sources didn't expose exact
+dates/teams/results.
+
+### Origami Cup 4
+
+```json
+{
+	"name": "Origami Cup 4",
+	"slug": "origami-cup-4",
+	"server": "strinova",
+	"format": "online",
+	"region": "Global", // TODO: confirm (OrigamiCup is an EN/global community)
+	"status": "finished", // TODO: confirm
+	"date": "2026-03-07/2026-03-15", // TODO: confirm exact dates (announced 2026-02-28, rosters 2026-03-04)
+	"image": "https://picsum.photos/seed/origami-cup-4/300/200", // TODO: real banner
+	"official": false,
+	"capacity": 8, // TODO: confirm
+	"websites": [{ "url": "https://www.twitch.tv/origamicup", "label": "Twitch" }]
+}
+```
+
+### EmikoAi Nya Nya Cup
+
+```json
+{
+	"name": "EmikoAi Nya Nya Cup",
+	"slug": "emikoai-nya-nya-cup",
+	"server": "strinova",
+	"format": "online",
+	"region": "Global", // TODO: confirm
+	"status": "finished", // TODO: confirm
+	"date": "2026-02-01", // TODO: confirm exact date(s) — unverified
+	"image": "https://picsum.photos/seed/emikoai-nya-nya-cup/300/200", // TODO: real banner
+	"official": false,
+	"capacity": 8, // TODO: confirm
+	"websites": [{ "url": "https://www.twitch.tv/emikoai_", "label": "Twitch" }]
+}
+```
+
+Sources: [Origami Cup 4 announcement](https://www.youtube.com/watch?v=TO8w1bOxZUQ),
+[OrigamiCup Twitch](https://www.twitch.tv/origamicup),
+[EmikoAi Twitch](https://www.twitch.tv/emikoai_).
+
+## Implementation notes
+
+- Transport + auth: `src/routes/api/mcp/+server.ts`
+- Protocol dispatch (pure, unit-tested): `src/lib/server/mcp/dispatch.ts`
+- Tool registry: `src/lib/server/mcp/tools.ts`
+- Shared write path: `createEvent()` in `src/lib/server/data/events.ts` (also
+  used by the admin UI), which emits `edit_history` tagged `mcp:create_event`.

--- a/src/lib/server/data/events.ts
+++ b/src/lib/server/data/events.ts
@@ -6,6 +6,7 @@ import * as table from '$lib/server/db/schema';
 import { processImageURL } from '$lib/server/storage';
 import type { Region } from '$lib/data/game';
 import { eq, or, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 import { safeParseDateRange } from '$lib/utils/date';
 import type { EventParticipant, StageNode } from '$lib/data/events';
 import type { GameAccount, GameAccountRegion, GameAccountServer, Player } from '$lib/data/players';
@@ -138,6 +139,149 @@ export function toDatabaseEventVideos(
 		url: video.url,
 		title: video.title || null
 	}));
+}
+
+export const EVENT_SERVERS = ['calabiyau', 'strinova'] as const;
+export const EVENT_FORMATS = ['lan', 'online', 'hybrid'] as const;
+export const EVENT_STATUSES = ['upcoming', 'live', 'finished', 'cancelled', 'postponed'] as const;
+
+/** Core fields needed to create an event, without UI-form coupling. */
+export interface CreateEventInput {
+	name: string;
+	slug: string;
+	official?: boolean;
+	server: string;
+	format: string;
+	region: Region;
+	image: string;
+	status: string;
+	capacity?: number;
+	date: string;
+	organizerIds?: string[];
+	websites?: { url: string; label?: string }[];
+	videos?: CreateEventData['videos'];
+}
+
+/**
+ * Create an event and its directly-owned records (organizers, websites,
+ * videos) in one transaction, emitting an `edit_history` row. This is the
+ * single canonical event-creation path, reused by the admin UI, the MCP
+ * server, and scripts. Authorization is the caller's responsibility — this
+ * trusts `editedBy`.
+ *
+ * `options.source` tags the provenance of the edit (e.g. 'mcp:create_event')
+ * in the audit trail so AI-originated creations are distinguishable.
+ */
+export async function createEvent(
+	data: CreateEventInput,
+	editedBy: string,
+	options: { source?: string } = {}
+): Promise<{ id: string }> {
+	const required: Array<[keyof CreateEventInput, unknown]> = [
+		['name', data.name],
+		['slug', data.slug],
+		['server', data.server],
+		['format', data.format],
+		['region', data.region],
+		['image', data.image],
+		['status', data.status],
+		['date', data.date]
+	];
+	const missing = required.filter(([, value]) => !value).map(([key]) => key);
+	if (missing.length > 0) {
+		throw new Error(`Missing required fields: ${missing.join(', ')}`);
+	}
+
+	if (!EVENT_SERVERS.includes(data.server as (typeof EVENT_SERVERS)[number])) {
+		throw new Error(
+			`Invalid server "${data.server}" (expected one of: ${EVENT_SERVERS.join(', ')})`
+		);
+	}
+	if (!EVENT_FORMATS.includes(data.format as (typeof EVENT_FORMATS)[number])) {
+		throw new Error(
+			`Invalid format "${data.format}" (expected one of: ${EVENT_FORMATS.join(', ')})`
+		);
+	}
+	if (!EVENT_STATUSES.includes(data.status as (typeof EVENT_STATUSES)[number])) {
+		throw new Error(
+			`Invalid status "${data.status}" (expected one of: ${EVENT_STATUSES.join(', ')})`
+		);
+	}
+
+	const [existing] = await db
+		.select({ id: table.event.id })
+		.from(table.event)
+		.where(eq(table.event.slug, data.slug))
+		.limit(1);
+	if (existing) {
+		throw new Error(`An event with slug "${data.slug}" already exists`);
+	}
+
+	const id = randomUUID();
+	const dbEvent = toDatabaseEvent({
+		name: data.name,
+		slug: data.slug,
+		official: data.official ?? false,
+		server: data.server,
+		format: data.format,
+		region: data.region,
+		image: data.image,
+		status: data.status,
+		capacity: data.capacity ?? 0,
+		date: data.date,
+		organizerIds: data.organizerIds ?? [],
+		websites: data.websites ?? [],
+		videos: data.videos ?? [],
+		casters: []
+	});
+
+	await db.transaction(async (tx) => {
+		await tx.insert(table.event).values({ id, ...dbEvent });
+
+		const organizerIds = data.organizerIds ?? [];
+		if (organizerIds.length > 0) {
+			await tx.insert(table.eventOrganizer).values(toDatabaseEventOrganizers(id, organizerIds));
+		}
+
+		const websites = (data.websites ?? []).filter((website) => website.url);
+		if (websites.length > 0) {
+			await tx.insert(table.eventWebsite).values(
+				websites.map((website) => ({
+					id: randomUUID(),
+					eventId: id,
+					url: website.url,
+					label: website.label || null,
+					createdAt: new Date(),
+					updatedAt: new Date()
+				}))
+			);
+		}
+
+		const videos = data.videos ?? [];
+		if (videos.length > 0) {
+			await tx.insert(table.eventVideo).values(
+				toDatabaseEventVideos(id, videos).map((video) => ({
+					...video,
+					id: randomUUID(),
+					createdAt: new Date(),
+					updatedAt: new Date()
+				}))
+			);
+		}
+
+		await tx.insert(table.editHistory).values({
+			id: randomUUID(),
+			tableName: 'event',
+			recordId: id,
+			fieldName: 'creation',
+			oldValue: null,
+			newValue: options.source ? `created:${options.source}` : 'created',
+			editedBy,
+			editedAt: new Date()
+		});
+	});
+
+	return { id };
 }
 
 // Get changes between old and new event data

--- a/src/lib/server/mcp/args.test.ts
+++ b/src/lib/server/mcp/args.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'bun:test';
+import { requireString } from './args';
+
+describe('requireString', () => {
+	it('returns the value for a valid non-empty string', () => {
+		expect(requireString({ slug: 'origami-cup-4' }, 'slug')).toBe('origami-cup-4');
+	});
+
+	it('throws when a required field is missing (the create_event bug)', () => {
+		// Previously String(undefined) === "undefined" slipped past the checks.
+		expect(() => requireString({ name: 'x' }, 'slug')).toThrow(
+			'Missing or invalid required field: slug'
+		);
+	});
+
+	it('throws on undefined / null / non-string values', () => {
+		expect(() => requireString({ slug: undefined }, 'slug')).toThrow();
+		expect(() => requireString({ slug: null }, 'slug')).toThrow();
+		expect(() => requireString({ slug: 123 }, 'slug')).toThrow();
+		expect(() => requireString({ slug: {} }, 'slug')).toThrow();
+	});
+
+	it('throws on empty or whitespace-only strings', () => {
+		expect(() => requireString({ slug: '' }, 'slug')).toThrow();
+		expect(() => requireString({ slug: '   ' }, 'slug')).toThrow();
+	});
+});

--- a/src/lib/server/mcp/args.ts
+++ b/src/lib/server/mcp/args.ts
@@ -1,0 +1,20 @@
+/**
+ * Argument validation helpers for MCP tools.
+ *
+ * MCP `inputSchema.required` is advertised to clients but NOT enforced by the
+ * dispatcher, so tool handlers must validate required arguments themselves.
+ * Kept free of DB/SvelteKit imports so it is unit-testable in isolation.
+ */
+
+/**
+ * Read a required string argument, rejecting missing/blank/non-string values.
+ * Without this, an omitted field would coerce (`String(undefined)`) to the
+ * literal "undefined" and slip past the data layer's truthiness checks.
+ */
+export function requireString(args: Record<string, unknown>, key: string): string {
+	const value = args[key];
+	if (typeof value !== 'string' || value.trim() === '') {
+		throw new Error(`Missing or invalid required field: ${key}`);
+	}
+	return value;
+}

--- a/src/lib/server/mcp/dispatch.test.ts
+++ b/src/lib/server/mcp/dispatch.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'bun:test';
+import {
+	dispatch,
+	MCP_PROTOCOL_VERSION,
+	type JsonRpcRequest,
+	type McpTool,
+	type McpIdentity
+} from './dispatch';
+
+const readTool: McpTool = {
+	name: 'echo',
+	description: 'echo args',
+	requiresWrite: false,
+	inputSchema: { type: 'object' },
+	handler: async (args) => ({ echoed: args })
+};
+
+const writeTool: McpTool = {
+	name: 'mutate',
+	description: 'mutate something',
+	requiresWrite: true,
+	inputSchema: { type: 'object' },
+	handler: async () => ({ done: true })
+};
+
+const throwingTool: McpTool = {
+	name: 'boom',
+	description: 'always throws',
+	requiresWrite: false,
+	inputSchema: { type: 'object' },
+	handler: async () => {
+		throw new Error('kaboom');
+	}
+};
+
+const TOOLS = [readTool, writeTool, throwingTool];
+const reader: McpIdentity = { userId: 'u-read', username: 'reader', canWrite: false };
+const writer: McpIdentity = { userId: 'u-write', username: 'writer', canWrite: true };
+
+interface RpcResponse {
+	jsonrpc: string;
+	id: number | string | null;
+	result?: {
+		protocolVersion?: string;
+		capabilities?: { tools?: unknown };
+		serverInfo?: { name?: string };
+		tools?: { name: string; description?: string; inputSchema?: unknown }[];
+		content?: { type: string; text: string }[];
+		isError?: boolean;
+	};
+	error?: { code: number; message: string };
+}
+
+async function rpc(
+	message: JsonRpcRequest,
+	identity: McpIdentity = reader
+): Promise<RpcResponse> {
+	return (await dispatch(message, identity, TOOLS)) as unknown as RpcResponse;
+}
+
+const call = (id: number | string | null | undefined, method: string, params?: Record<string, unknown>) =>
+	rpc({ jsonrpc: '2.0', id, method, params });
+
+describe('dispatch — protocol', () => {
+	it('initialize advertises the protocol version, tool capability and server info', async () => {
+		const res = await call(1, 'initialize');
+		expect(res.jsonrpc).toBe('2.0');
+		expect(res.id).toBe(1);
+		expect(res.result?.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+		expect(res.result?.capabilities?.tools).toBeDefined();
+		expect(res.result?.serverInfo?.name).toBe('lemontv-mcp');
+	});
+
+	it('tools/list returns each tool with name, description, inputSchema', async () => {
+		const res = await call(2, 'tools/list');
+		expect(res.result?.tools?.map((t) => t.name)).toEqual(['echo', 'mutate', 'boom']);
+		expect(res.result?.tools?.[0]).toHaveProperty('inputSchema');
+	});
+
+	it('ping returns an empty result', async () => {
+		const res = await call(3, 'ping');
+		expect(res.result).toEqual({});
+	});
+
+	it('returns method-not-found for unknown methods', async () => {
+		const res = await call(4, 'does/not/exist');
+		expect(res.error?.code).toBe(-32601);
+	});
+
+	it('rejects malformed (non-2.0) messages', async () => {
+		const res = await rpc({ jsonrpc: '1.0' as never, id: 9, method: 'ping' });
+		expect(res.error?.code).toBe(-32600);
+	});
+
+	it('treats id-less messages as notifications (no reply)', async () => {
+		expect(
+			await dispatch({ jsonrpc: '2.0', method: 'notifications/initialized' }, reader, TOOLS)
+		).toBeNull();
+		// Unknown notification (no id) also yields no reply.
+		expect(await dispatch({ jsonrpc: '2.0', method: 'whatever' }, reader, TOOLS)).toBeNull();
+	});
+});
+
+describe('dispatch — tools/call', () => {
+	it('runs a read tool and wraps the result as MCP text content', async () => {
+		const res = await rpc({
+			jsonrpc: '2.0',
+			id: 5,
+			method: 'tools/call',
+			params: { name: 'echo', arguments: { a: 1 } }
+		});
+		expect(res.result?.isError).toBeUndefined();
+		expect(JSON.parse(res.result!.content![0].text)).toEqual({ echoed: { a: 1 } });
+	});
+
+	it('errors on an unknown tool', async () => {
+		const res = await rpc({
+			jsonrpc: '2.0',
+			id: 6,
+			method: 'tools/call',
+			params: { name: 'nope' }
+		});
+		expect(res.error?.code).toBe(-32602);
+	});
+
+	it('DENIES a write tool to a read-only identity (the security guard)', async () => {
+		const res = await rpc({
+			jsonrpc: '2.0',
+			id: 7,
+			method: 'tools/call',
+			params: { name: 'mutate' }
+		});
+		expect(res.result?.isError).toBe(true);
+		expect(res.result!.content![0].text).toContain('requires a write-scoped token');
+	});
+
+	it('ALLOWS a write tool for a write-capable identity', async () => {
+		const res = await rpc(
+			{ jsonrpc: '2.0', id: 8, method: 'tools/call', params: { name: 'mutate' } },
+			writer
+		);
+		expect(res.result?.isError).toBeUndefined();
+		expect(JSON.parse(res.result!.content![0].text)).toEqual({ done: true });
+	});
+
+	it('surfaces a throwing handler as an isError result, not a crash', async () => {
+		const res = await rpc({
+			jsonrpc: '2.0',
+			id: 10,
+			method: 'tools/call',
+			params: { name: 'boom' }
+		});
+		expect(res.result?.isError).toBe(true);
+		expect(res.result!.content![0].text).toContain('kaboom');
+	});
+});

--- a/src/lib/server/mcp/dispatch.ts
+++ b/src/lib/server/mcp/dispatch.ts
@@ -1,0 +1,120 @@
+/**
+ * Authorized MCP server — pure JSON-RPC 2.0 / MCP dispatch.
+ *
+ * Transport- and database-agnostic: the tool registry is injected, so this
+ * module imports nothing app-specific and is unit-testable in isolation.
+ * Concrete (DB-backed) tools live in `./tools`; the HTTP transport + auth in
+ * `src/routes/api/mcp/+server.ts`.
+ */
+export const MCP_PROTOCOL_VERSION = '2024-11-05';
+export const MCP_SERVER_INFO = { name: 'lemontv-mcp', version: '0.1.0' } as const;
+
+/** The authenticated caller, resolved from a Personal Access Token. */
+export interface McpIdentity {
+	userId: string;
+	username: string;
+	canWrite: boolean;
+}
+
+export interface JsonRpcRequest {
+	jsonrpc: '2.0';
+	id?: string | number | null;
+	method: string;
+	params?: Record<string, unknown>;
+}
+
+export interface McpTool {
+	name: string;
+	description: string;
+	/** When true, the caller must have resolved write capability. */
+	requiresWrite: boolean;
+	inputSchema: Record<string, unknown>;
+	handler: (args: Record<string, unknown>, identity: McpIdentity) => Promise<unknown>;
+}
+
+function rpcResult(id: JsonRpcRequest['id'], result: unknown) {
+	return { jsonrpc: '2.0' as const, id: id ?? null, result };
+}
+
+function rpcError(id: JsonRpcRequest['id'], code: number, message: string) {
+	return { jsonrpc: '2.0' as const, id: id ?? null, error: { code, message } };
+}
+
+/**
+ * Handle one JSON-RPC message against the given tool registry. Returns the
+ * response object, or `null` for notifications (which take no reply).
+ */
+export async function dispatch(
+	message: JsonRpcRequest,
+	identity: McpIdentity,
+	tools: McpTool[]
+): Promise<object | null> {
+	if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') {
+		return rpcError(message?.id ?? null, -32600, 'Invalid Request');
+	}
+
+	const { method, id, params } = message;
+	const isNotification = id === undefined;
+
+	switch (method) {
+		case 'initialize':
+			return rpcResult(id, {
+				protocolVersion: MCP_PROTOCOL_VERSION,
+				capabilities: { tools: {} },
+				serverInfo: MCP_SERVER_INFO
+			});
+
+		case 'notifications/initialized':
+		case 'notifications/cancelled':
+			return null;
+
+		case 'ping':
+			return rpcResult(id, {});
+
+		case 'tools/list':
+			return rpcResult(id, {
+				tools: tools.map(({ name, description, inputSchema }) => ({
+					name,
+					description,
+					inputSchema
+				}))
+			});
+
+		case 'tools/call': {
+			const toolName = (params?.name as string) ?? '';
+			const args = (params?.arguments as Record<string, unknown>) ?? {};
+			const tool = tools.find((t) => t.name === toolName);
+			if (!tool) {
+				return rpcError(id, -32602, `Unknown tool: ${toolName}`);
+			}
+			// Deny-by-default: write tools require resolved write capability.
+			if (tool.requiresWrite && !identity.canWrite) {
+				return rpcResult(id, {
+					content: [
+						{
+							type: 'text',
+							text: `Error: the tool "${toolName}" requires a write-scoped token held by an editor or admin.`
+						}
+					],
+					isError: true
+				});
+			}
+			try {
+				const result = await tool.handler(args, identity);
+				return rpcResult(id, {
+					content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+				});
+			} catch (error) {
+				const text = error instanceof Error ? error.message : 'Tool execution failed';
+				console.error(`[MCP] Tool "${toolName}" failed:`, error);
+				return rpcResult(id, {
+					content: [{ type: 'text', text: `Error: ${text}` }],
+					isError: true
+				});
+			}
+		}
+
+		default:
+			return isNotification ? null : rpcError(id, -32601, `Method not found: ${method}`);
+	}
+}

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -1,0 +1,20 @@
+/**
+ * Authorized MCP server — composition point.
+ *
+ * Binds the pure protocol `dispatch` (./dispatch) to the concrete DB-backed
+ * tool registry (./tools). The HTTP transport + authentication lives in the
+ * SvelteKit route `src/routes/api/mcp/+server.ts`.
+ */
+import { dispatch, type JsonRpcRequest, type McpIdentity } from './dispatch';
+import { TOOLS } from './tools';
+
+export { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from './dispatch';
+export type { McpIdentity } from './dispatch';
+
+/** Handle one JSON-RPC message against the live tool registry. */
+export function handleMcpMessage(
+	message: JsonRpcRequest,
+	identity: McpIdentity
+): Promise<object | null> {
+	return dispatch(message, identity, TOOLS);
+}

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -10,6 +10,7 @@ import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { createEvent, EVENT_FORMATS, EVENT_SERVERS, EVENT_STATUSES } from '$lib/server/data/events';
 import type { McpTool } from './dispatch';
+import { requireString } from './args';
 
 const EVENT_SUMMARY_COLUMNS = {
 	id: table.event.id,
@@ -134,16 +135,19 @@ export const TOOLS: McpTool[] = [
 			additionalProperties: false
 		},
 		handler: async (args, identity) => {
+			// Enforce required fields up front (dispatch does not validate
+			// inputSchema.required); the data layer then validates enum values.
+			const slug = requireString(args, 'slug');
 			const { id } = await createEvent(
 				{
-					name: String(args.name),
-					slug: String(args.slug),
-					server: String(args.server),
-					format: String(args.format),
-					region: args.region as never,
-					status: String(args.status),
-					date: String(args.date),
-					image: String(args.image),
+					name: requireString(args, 'name'),
+					slug,
+					server: requireString(args, 'server'),
+					format: requireString(args, 'format'),
+					region: requireString(args, 'region') as never,
+					status: requireString(args, 'status'),
+					date: requireString(args, 'date'),
+					image: requireString(args, 'image'),
 					official: Boolean(args.official ?? false),
 					capacity: typeof args.capacity === 'number' ? args.capacity : 0,
 					organizerIds: Array.isArray(args.organizerIds) ? (args.organizerIds as string[]) : [],
@@ -154,7 +158,7 @@ export const TOOLS: McpTool[] = [
 				identity.userId,
 				{ source: 'mcp:create_event' }
 			);
-			return { id, slug: String(args.slug), created: true };
+			return { id, slug, created: true };
 		}
 	}
 ];

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -1,0 +1,160 @@
+/**
+ * Authorized MCP server — concrete tool registry.
+ *
+ * Each tool wraps the shared data layer (`$lib/server/data/*`) so MCP edits get
+ * the same validation + `edit_history` attribution as the admin UI. Write tools
+ * are flagged `requiresWrite` and enforced by `dispatch`.
+ */
+import { desc, eq, or } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import { createEvent, EVENT_FORMATS, EVENT_SERVERS, EVENT_STATUSES } from '$lib/server/data/events';
+import type { McpTool } from './dispatch';
+
+const EVENT_SUMMARY_COLUMNS = {
+	id: table.event.id,
+	slug: table.event.slug,
+	name: table.event.name,
+	status: table.event.status,
+	region: table.event.region,
+	format: table.event.format,
+	server: table.event.server,
+	official: table.event.official,
+	capacity: table.event.capacity,
+	date: table.event.date
+} as const;
+
+export const TOOLS: McpTool[] = [
+	{
+		name: 'list_events',
+		description:
+			'List LemonTV tournaments/events (most recent first). Optionally filter by status.',
+		requiresWrite: false,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				status: {
+					type: 'string',
+					enum: [...EVENT_STATUSES],
+					description: 'Optional status filter.'
+				},
+				limit: {
+					type: 'integer',
+					minimum: 1,
+					maximum: 200,
+					description: 'Max events to return (default 50).'
+				}
+			},
+			additionalProperties: false
+		},
+		handler: async (args) => {
+			const limit = Math.min(Math.max(Number(args.limit) || 50, 1), 200);
+			const status = typeof args.status === 'string' ? args.status : undefined;
+			const rows = await db
+				.select(EVENT_SUMMARY_COLUMNS)
+				.from(table.event)
+				.where(
+					status ? eq(table.event.status, status as (typeof EVENT_STATUSES)[number]) : undefined
+				)
+				.orderBy(desc(table.event.date))
+				.limit(limit);
+			return { count: rows.length, events: rows };
+		}
+	},
+	{
+		name: 'get_event',
+		description: 'Get a single LemonTV event by its id or slug.',
+		requiresWrite: false,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				idOrSlug: { type: 'string', description: 'The event id or slug.' }
+			},
+			required: ['idOrSlug'],
+			additionalProperties: false
+		},
+		handler: async (args) => {
+			const idOrSlug = String(args.idOrSlug ?? '');
+			if (!idOrSlug) throw new Error('idOrSlug is required');
+			const [row] = await db
+				.select()
+				.from(table.event)
+				.where(or(eq(table.event.id, idOrSlug), eq(table.event.slug, idOrSlug)))
+				.limit(1);
+			return row ?? null;
+		}
+	},
+	{
+		name: 'create_event',
+		description:
+			'Create a new LemonTV tournament/event. Returns the new event id. Teams, results, and casters are added separately. Edits are attributed to the token owner.',
+		requiresWrite: true,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				name: { type: 'string', description: 'Display name, e.g. "Origami Cup 4".' },
+				slug: {
+					type: 'string',
+					description: 'URL slug, lowercase-kebab, unique, e.g. "origami-cup-4".'
+				},
+				server: { type: 'string', enum: [...EVENT_SERVERS], description: 'Game server.' },
+				format: { type: 'string', enum: [...EVENT_FORMATS], description: 'Competition format.' },
+				region: {
+					type: 'string',
+					description: 'Region, e.g. "Global", "NA", "EU", "APAC", "CN", "SA".'
+				},
+				status: { type: 'string', enum: [...EVENT_STATUSES], description: 'Event status.' },
+				date: { type: 'string', description: 'YYYY-MM-DD or a range YYYY-MM-DD/YYYY-MM-DD.' },
+				image: {
+					type: 'string',
+					description: 'Banner/logo URL (a placeholder URL is acceptable).'
+				},
+				official: {
+					type: 'boolean',
+					description: 'Whether it is an official event (default false).'
+				},
+				capacity: { type: 'integer', minimum: 0, description: 'Team capacity (default 0).' },
+				organizerIds: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'Existing organizer ids to attach (optional).'
+				},
+				websites: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: { url: { type: 'string' }, label: { type: 'string' } },
+						required: ['url'],
+						additionalProperties: false
+					},
+					description: 'Related links (optional).'
+				}
+			},
+			required: ['name', 'slug', 'server', 'format', 'region', 'status', 'date', 'image'],
+			additionalProperties: false
+		},
+		handler: async (args, identity) => {
+			const { id } = await createEvent(
+				{
+					name: String(args.name),
+					slug: String(args.slug),
+					server: String(args.server),
+					format: String(args.format),
+					region: args.region as never,
+					status: String(args.status),
+					date: String(args.date),
+					image: String(args.image),
+					official: Boolean(args.official ?? false),
+					capacity: typeof args.capacity === 'number' ? args.capacity : 0,
+					organizerIds: Array.isArray(args.organizerIds) ? (args.organizerIds as string[]) : [],
+					websites: Array.isArray(args.websites)
+						? (args.websites as { url: string; label?: string }[])
+						: []
+				},
+				identity.userId,
+				{ source: 'mcp:create_event' }
+			);
+			return { id, slug: String(args.slug), created: true };
+		}
+	}
+];

--- a/src/routes/(user)/admin/events/+page.server.ts
+++ b/src/routes/(user)/admin/events/+page.server.ts
@@ -9,6 +9,7 @@ import {
 	type CreateEventData,
 	type UpdateEventData,
 	type EventTeamPlayerData,
+	createEvent,
 	toDatabaseEvent,
 	toDatabaseEventOrganizers,
 	toDatabaseEventVideos,
@@ -310,51 +311,10 @@ export const actions = {
 		}
 
 		try {
-			const eventId = randomUUID();
-			const dbEvent = toDatabaseEvent(eventData);
-			await db.insert(table.event).values({
-				id: eventId,
-				...dbEvent
-			});
-
-			// Handle event organizers
-			if (eventData.organizerIds && eventData.organizerIds.length > 0) {
-				await db
-					.insert(table.eventOrganizer)
-					.values(toDatabaseEventOrganizers(eventId, eventData.organizerIds));
-			}
-
-			// Handle event websites
-			if (eventData.websites && eventData.websites.length > 0) {
-				const websiteValues = eventData.websites
-					.filter((website) => website.url) // Only include websites with URLs
-					.map((website) => ({
-						id: randomUUID(),
-						eventId,
-						url: website.url,
-						label: website.label || null,
-						createdAt: new Date(),
-						updatedAt: new Date()
-					}));
-
-				if (websiteValues.length > 0) {
-					await db.insert(table.eventWebsite).values(websiteValues);
-				}
-			}
-
-			// Handle event videos
-			if (eventData.videos && eventData.videos.length > 0) {
-				const videoValues = toDatabaseEventVideos(eventId, eventData.videos).map((video) => ({
-					...video,
-					id: randomUUID(),
-					createdAt: new Date(),
-					updatedAt: new Date()
-				}));
-
-				if (videoValues.length > 0) {
-					await db.insert(table.eventVideo).values(videoValues);
-				}
-			}
+			// Core event creation (event row + organizers + websites + videos +
+			// creation history) goes through the shared service so the admin UI,
+			// the MCP server, and scripts all write events the same way.
+			const { id: eventId } = await createEvent(eventData, result.userId);
 
 			// Handle event casters
 			const castersData = formData.get('casters') as string;
@@ -425,18 +385,6 @@ export const actions = {
 			if (teamSlogansData) {
 				await handleTeamSlogansUpdate(eventId, teamSlogansData, result.userId);
 			}
-
-			// Add edit history
-			await db.insert(table.editHistory).values({
-				id: randomUUID(),
-				tableName: 'event',
-				recordId: eventId,
-				fieldName: 'creation',
-				oldValue: null,
-				newValue: 'created',
-				editedBy: result.userId,
-				editedAt: new Date()
-			});
 
 			return {
 				success: true,

--- a/src/routes/api/mcp/+server.ts
+++ b/src/routes/api/mcp/+server.ts
@@ -1,0 +1,73 @@
+/**
+ * Authorized MCP server — HTTP transport.
+ *
+ * Speaks MCP over JSON-RPC via HTTP POST, authenticated by a LemonTV Personal
+ * Access Token (`Authorization: Bearer lemon_pat_…`). NOT mounted under
+ * /api/public/ (which is pre-auth) — this route authenticates every request
+ * itself and resolves the caller's write capability before dispatch.
+ */
+import { json, error as kitError } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { validateMcpToken } from '$lib/server/security/mcp-token-store';
+import { handleMcpMessage, type McpIdentity } from '$lib/server/mcp/server';
+
+function bearerToken(request: Request): string | null {
+	const header = request.headers.get('authorization');
+	if (!header) return null;
+	const match = header.match(/^Bearer\s+(.+)$/i);
+	return match ? match[1].trim() : null;
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	const token = bearerToken(request);
+	if (!token) {
+		return json(
+			{ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Missing bearer token' } },
+			{ status: 401, headers: { 'WWW-Authenticate': 'Bearer' } }
+		);
+	}
+
+	const validation = await validateMcpToken(token);
+	if (validation.status !== 'valid') {
+		return json(
+			{
+				jsonrpc: '2.0',
+				id: null,
+				error: { code: -32001, message: `Unauthorized (${validation.reason})` }
+			},
+			{ status: 401 }
+		);
+	}
+
+	const identity: McpIdentity = {
+		userId: validation.user.id,
+		username: validation.user.username,
+		canWrite: validation.canWrite
+	};
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json(
+			{ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+			{ status: 400 }
+		);
+	}
+
+	// JSON-RPC batch or single message.
+	if (Array.isArray(body)) {
+		const responses = (
+			await Promise.all(body.map((msg) => handleMcpMessage(msg as never, identity)))
+		).filter((r): r is object => r !== null);
+		return responses.length === 0 ? new Response(null, { status: 202 }) : json(responses);
+	}
+
+	const response = await handleMcpMessage(body as never, identity);
+	return response === null ? new Response(null, { status: 202 }) : json(response);
+};
+
+// This server does not support the optional server-initiated SSE stream.
+export const GET: RequestHandler = () => {
+	throw kitError(405, 'Method Not Allowed — POST JSON-RPC to this endpoint');
+};


### PR DESCRIPTION
**Phase 2/3 of the authorized MCP server.** Stacked on #49 (the token foundation) — it uses `validateMcpToken` and the `mcp_token` table, so **merge #49 first**. Base is set to the #49 branch so this diff shows only the new work.

With this, an authorized editor can manage events from an AI client (Claude Desktop/Code), every action attributed to them and audited.

## One shared write path
`createEvent()` is extracted into `src/lib/server/data/events.ts` — a single transactional `(data, editedBy, { source })` service that inserts the event + organizers + websites + videos and emits `edit_history`. **The admin create action now calls it**, so the admin UI, the MCP server, and scripts all create events the same way (no duplicated write logic). Casters/results/teams remain in the admin action for now.

## MCP server
| File | Role |
|---|---|
| `src/lib/server/mcp/dispatch.ts` | Pure JSON-RPC 2.0 / MCP dispatch (`initialize` / `tools/list` / `tools/call`). Tool registry injected ⇒ unit-testable with no DB. **Deny-by-default write guard.** |
| `src/lib/server/mcp/tools.ts` | `list_events`, `get_event` (read), `create_event` (write) over the data layer. AI edits tagged `edit_history` `mcp:create_event`. |
| `src/routes/api/mcp/+server.ts` | Streamable-HTTP transport, authenticated by a Bearer PAT; resolves read vs write capability. Mounted at `/api/mcp` — **not** under `/api/public/` (which is pre-auth). |

## Security
- Every request authenticates via `validateMcpToken`; an invalid/expired/revoked token → 401.
- `create_event` is a write tool: denied unless the token resolves to write capability (editor/admin). Covered by a unit test.
- `create_event` validates enums + slug-uniqueness and trusts only the token owner's id for `editedBy`.

## Docs
`docs/MCP_SERVER.md` — how to connect from Claude, the tool reference, and ready-to-send `create_event` payloads for two tournaments missing from LemonTV (**Origami Cup 4**, **EmikoAi Nya Nya Cup**) with unverified fields flagged `TODO`.

## Verification
- `bun run check` → **0 errors**
- `bun test src/` → **90 pass / 0 fail** (11 new dispatch tests incl. the write guard)
- ⚠️ Deploying the write path requires the `mcp_token` table from #49 to be pushed (`bun run db:prod:push`).

## Not in scope (later phases)
- `mcp_audit_log` (reads/denials) + `mcp_rate_limit`, and write tools for teams/players/matches.
- Actually inserting the two tournaments — needs a deployed endpoint + a minted write token, or the admin UI (payloads are prepared in the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)