### PR TITLE
Phase 3: MCP audit log + per-token rate limiting

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -121,10 +121,21 @@ Sources: [Origami Cup 4 announcement](https://www.youtube.com/watch?v=TO8w1bOxZU
 [OrigamiCup Twitch](https://www.twitch.tv/origamicup),
 [EmikoAi Twitch](https://www.twitch.tv/emikoai_).
 
+## Rate limits & audit
+
+- **Rate limit:** each token gets a persisted token bucket (`mcp_rate_limit`) —
+  a burst of 120 requests, refilling 2/second. Exceeding it returns an
+  `isError` result with a retry-after hint; it does not drop the connection.
+- **Audit log:** every tool call's outcome (`success` / `denied` / `error` /
+  `rate_limited`) is recorded in `mcp_audit_log` with the token, user, tool, and
+  IP — so AI-driven access is moderatable and traceable to a revocable token.
+  (Successful data mutations are additionally in `edit_history`.)
+
 ## Implementation notes
 
 - Transport + auth: `src/routes/api/mcp/+server.ts`
 - Protocol dispatch (pure, unit-tested): `src/lib/server/mcp/dispatch.ts`
 - Tool registry: `src/lib/server/mcp/tools.ts`
+- Rate-limit core (pure, tested) + DB hooks: `src/lib/server/mcp/rate-limit.ts`, `hooks.ts`
 - Shared write path: `createEvent()` in `src/lib/server/data/events.ts` (also
   used by the admin UI), which emits `edit_history` tagged `mcp:create_event`.

--- a/drizzle/0001_empty_zzzax.sql
+++ b/drizzle/0001_empty_zzzax.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `mcp_audit_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`token_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`tool` text NOT NULL,
+	`status` text NOT NULL,
+	`detail` text,
+	`ip` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`token_id`) REFERENCES `mcp_token`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `idx_mcp_audit_token` ON `mcp_audit_log` (`token_id`);--> statement-breakpoint
+CREATE INDEX `idx_mcp_audit_created` ON `mcp_audit_log` (`created_at`);--> statement-breakpoint
+CREATE TABLE `mcp_rate_limit` (
+	`token_id` text PRIMARY KEY NOT NULL,
+	`tokens` real NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`token_id`) REFERENCES `mcp_token`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,4600 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c1ed0da4-41c0-4704-95e9-13adcb144137",
+  "prevId": "d7345681-d07f-4ef9-b98b-f7d54ced22cc",
+  "tables": {
+    "role": {
+      "name": "role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_role": {
+      "name": "user_role",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_role_user": {
+          "name": "idx_user_role_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_role_role": {
+          "name": "idx_user_role_role",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_role_user_id_user_id_fk": {
+          "name": "user_role_user_id_user_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_role_id_fk": {
+          "name": "user_role_role_id_role_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_role_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_role_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_user": {
+          "name": "idx_session_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_token": {
+      "name": "password_reset_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_reset_token_token_unique": {
+          "name": "password_reset_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "password_reset_token_user_id_user_id_fk": {
+          "name": "password_reset_token_user_id_user_id_fk",
+          "tableFrom": "password_reset_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_token": {
+      "name": "mcp_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_token_token_hash_unique": {
+          "name": "mcp_token_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_token_user": {
+          "name": "idx_mcp_token_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_token": {
+          "name": "idx_mcp_audit_token",
+          "columns": [
+            "token_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_audit_created": {
+          "name": "idx_mcp_audit_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_token_id_mcp_token_id_fk": {
+          "name": "mcp_audit_log_token_id_mcp_token_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_audit_log_user_id_user_id_fk": {
+          "name": "mcp_audit_log_user_id_user_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_rate_limit": {
+      "name": "mcp_rate_limit",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_rate_limit_token_id_mcp_token_id_fk": {
+          "name": "mcp_rate_limit_token_id_mcp_token_id_fk",
+          "tableFrom": "mcp_rate_limit",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player": {
+      "name": "player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_slug_unique": {
+          "name": "player_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_player_user": {
+          "name": "idx_player_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_player_nationality": {
+          "name": "idx_player_nationality",
+          "columns": [
+            "nationality"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_user_id_user_id_fk": {
+          "name": "player_user_id_user_id_fk",
+          "tableFrom": "player",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_additional_nationality": {
+      "name": "player_additional_nationality",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pan_player": {
+          "name": "idx_pan_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pan_nationality": {
+          "name": "idx_pan_nationality",
+          "columns": [
+            "nationality"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_additional_nationality_player_id_player_id_fk": {
+          "name": "player_additional_nationality_player_id_player_id_fk",
+          "tableFrom": "player_additional_nationality",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_additional_nationality_player_id_nationality_pk": {
+          "columns": [
+            "player_id",
+            "nationality"
+          ],
+          "name": "player_additional_nationality_player_id_nationality_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_alias": {
+      "name": "player_alias",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pa_player": {
+          "name": "idx_pa_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_alias_player_id_player_id_fk": {
+          "name": "player_alias_player_id_player_id_fk",
+          "tableFrom": "player_alias",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_alias": {
+      "name": "team_alias",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ta_team": {
+          "name": "idx_ta_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_alias_team_id_alias_unique": {
+          "name": "team_alias_team_id_alias_unique",
+          "columns": [
+            "team_id",
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_alias_team_id_teams_id_fk": {
+          "name": "team_alias_team_id_teams_id_fk",
+          "tableFrom": "team_alias",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_player": {
+      "name": "team_player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_on": {
+          "name": "ended_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tp_team": {
+          "name": "idx_tp_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tp_player": {
+          "name": "idx_tp_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tp_role": {
+          "name": "idx_tp_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_player_team_id_teams_id_fk": {
+          "name": "team_player_team_id_teams_id_fk",
+          "tableFrom": "team_player",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_slogan": {
+      "name": "team_slogan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slogan": {
+          "name": "slogan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "team_slogan_team_slogan_dupe_guard": {
+          "name": "team_slogan_team_slogan_dupe_guard",
+          "columns": [
+            "team_id",
+            "event_id",
+            "slogan"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_slogan_team_id_teams_id_fk": {
+          "name": "team_slogan_team_id_teams_id_fk",
+          "tableFrom": "team_slogan",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "team_slogan_event_id_event_id_fk": {
+          "name": "team_slogan_event_id_event_id_fk",
+          "tableFrom": "team_slogan",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_account": {
+      "name": "game_account",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_name": {
+          "name": "current_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ga_player": {
+          "name": "idx_ga_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_account_player_id_player_id_fk": {
+          "name": "game_account_player_id_player_id_fk",
+          "tableFrom": "game_account",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_account_server_account_id_pk": {
+          "columns": [
+            "server",
+            "account_id"
+          ],
+          "name": "game_account_server_account_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "social_account": {
+      "name": "social_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overriding_url": {
+          "name": "overriding_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_psa_platform": {
+          "name": "idx_psa_platform",
+          "columns": [
+            "platform_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psa_player": {
+          "name": "idx_psa_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psa_account": {
+          "name": "idx_psa_account",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "social_account_platform_id_social_platform_id_fk": {
+          "name": "social_account_platform_id_social_platform_id_fk",
+          "tableFrom": "social_account",
+          "tableTo": "social_platform",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "social_account_player_id_player_id_fk": {
+          "name": "social_account_player_id_player_id_fk",
+          "tableFrom": "social_account",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "social_platform": {
+      "name": "social_platform",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_template": {
+          "name": "url_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event": {
+      "name": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "official": {
+          "name": "official",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_slug_unique": {
+          "name": "event_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_caster": {
+      "name": "event_caster",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_caster_event_id_event_id_fk": {
+          "name": "event_caster_event_id_event_id_fk",
+          "tableFrom": "event_caster",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_caster_player_id_player_id_fk": {
+          "name": "event_caster_player_id_player_id_fk",
+          "tableFrom": "event_caster",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_caster_event_id_player_id_pk": {
+          "columns": [
+            "event_id",
+            "player_id"
+          ],
+          "name": "event_caster_event_id_player_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_organizer": {
+      "name": "event_organizer",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_eo_event": {
+          "name": "idx_eo_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_organizer_event_id_event_id_fk": {
+          "name": "event_organizer_event_id_event_id_fk",
+          "tableFrom": "event_organizer",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_organizer_organizer_id_organizer_id_fk": {
+          "name": "event_organizer_organizer_id_organizer_id_fk",
+          "tableFrom": "event_organizer",
+          "tableTo": "organizer",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_organizer_event_id_organizer_id_pk": {
+          "columns": [
+            "event_id",
+            "organizer_id"
+          ],
+          "name": "event_organizer_event_id_organizer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_result": {
+      "name": "event_result",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank_to": {
+          "name": "rank_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_amount": {
+          "name": "prize_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_currency": {
+          "name": "prize_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_result_event_id_event_id_fk": {
+          "name": "event_result_event_id_event_id_fk",
+          "tableFrom": "event_result",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_result_team_id_teams_id_fk": {
+          "name": "event_result_team_id_teams_id_fk",
+          "tableFrom": "event_result",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_team": {
+      "name": "event_team",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_team_event_id_event_id_fk": {
+          "name": "event_team_event_id_event_id_fk",
+          "tableFrom": "event_team",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "event_team_team_id_teams_id_fk": {
+          "name": "event_team_team_id_teams_id_fk",
+          "tableFrom": "event_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_team_event_id_team_id_pk": {
+          "columns": [
+            "event_id",
+            "team_id"
+          ],
+          "name": "event_team_event_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_team_player": {
+      "name": "event_team_player",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_etp_event": {
+          "name": "idx_etp_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_team_player_event_id_event_id_fk": {
+          "name": "event_team_player_event_id_event_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_team_player_team_id_teams_id_fk": {
+          "name": "event_team_player_team_id_teams_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_team_player_player_id_player_id_fk": {
+          "name": "event_team_player_player_id_player_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_team_player_event_id_team_id_player_id_pk": {
+          "columns": [
+            "event_id",
+            "team_id",
+            "player_id"
+          ],
+          "name": "event_team_player_event_id_team_id_player_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_video": {
+      "name": "event_video",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_ev_event": {
+          "name": "idx_ev_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_video_event_id_event_id_fk": {
+          "name": "event_video_event_id_event_id_fk",
+          "tableFrom": "event_video",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_website": {
+      "name": "event_website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_website_event_id_event_id_fk": {
+          "name": "event_website_event_id_event_id_fk",
+          "tableFrom": "event_website",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizer": {
+      "name": "organizer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "organizer_slug_unique": {
+          "name": "organizer_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type": {
+          "name": "type",
+          "value": "\"organizer\".\"type\" IS NULL OR \"organizer\".\"type\" IN ('individual', 'organization', 'community', 'tournament_series', 'league')"
+        }
+      }
+    },
+    "organizer_user": {
+      "name": "organizer_user",
+      "columns": {
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizer_user_organizer_id_organizer_id_fk": {
+          "name": "organizer_user_organizer_id_organizer_id_fk",
+          "tableFrom": "organizer_user",
+          "tableTo": "organizer",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizer_user_user_id_user_id_fk": {
+          "name": "organizer_user_user_id_user_id_fk",
+          "tableFrom": "organizer_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organizer_user_organizer_id_user_id_pk": {
+          "columns": [
+            "organizer_id",
+            "user_id"
+          ],
+          "name": "organizer_user_organizer_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "character": {
+      "name": "character",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "map": {
+      "name": "map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_game_match": {
+          "name": "idx_game_match",
+          "columns": [
+            "match_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_match_id_match_id_fk": {
+          "name": "game_match_id_match_id_fk",
+          "tableFrom": "game",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_map_id_map_id_fk": {
+          "name": "game_map_id_map_id_fk",
+          "tableFrom": "game",
+          "tableTo": "map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_player_score": {
+      "name": "game_player_score",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_first_half": {
+          "name": "character_first_half",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character_second_half": {
+          "name": "character_second_half",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damage_score": {
+          "name": "damage_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knocks": {
+          "name": "knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_gps_game": {
+          "name": "idx_gps_game",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_team": {
+          "name": "idx_gps_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_account": {
+          "name": "idx_gps_account",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_char1": {
+          "name": "idx_gps_char1",
+          "columns": [
+            "character_first_half"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_char2": {
+          "name": "idx_gps_char2",
+          "columns": [
+            "character_second_half"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_player_score_game_id_game_id_fk": {
+          "name": "game_player_score_game_id_game_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_team_id_teams_id_fk": {
+          "name": "game_player_score_team_id_teams_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_character_first_half_character_id_fk": {
+          "name": "game_player_score_character_first_half_character_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_first_half"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_character_second_half_character_id_fk": {
+          "name": "game_player_score_character_second_half_character_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_second_half"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_team": {
+      "name": "game_team",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_gt_game": {
+          "name": "idx_gt_game",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gt_team": {
+          "name": "idx_gt_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_team_game_id_game_id_fk": {
+          "name": "game_team_game_id_game_id_fk",
+          "tableFrom": "game_team",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_team_team_id_teams_id_fk": {
+          "name": "game_team_team_id_teams_id_fk",
+          "tableFrom": "game_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_team_game_id_team_id_pk": {
+          "columns": [
+            "game_id",
+            "team_id"
+          ],
+          "name": "game_team_game_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "position": {
+          "name": "position",
+          "value": "\"game_team\".\"position\" IN (0, 1)"
+        }
+      }
+    },
+    "game_vod": {
+      "name": "game_vod",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "official": {
+          "name": "official",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available": {
+          "name": "available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_vod_game_id_game_id_fk": {
+          "name": "game_vod_game_id_game_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_vod_player_id_player_id_fk": {
+          "name": "game_vod_player_id_player_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_vod_team_id_teams_id_fk": {
+          "name": "game_vod_team_id_teams_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_vod_game_id_url_pk": {
+          "columns": [
+            "game_id",
+            "url"
+          ],
+          "name": "game_vod_game_id_url_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match": {
+      "name": "match",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_match_stage": {
+          "name": "idx_match_stage",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "format": {
+          "name": "format",
+          "value": "\"match\".\"format\" IN ('BO1', 'BO3', 'BO5')"
+        }
+      }
+    },
+    "match_map": {
+      "name": "match_map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_picker_position": {
+          "name": "map_picker_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side_picker_position": {
+          "name": "side_picker_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_map_match_id_match_id_fk": {
+          "name": "match_map_match_id_match_id_fk",
+          "tableFrom": "match_map",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_map_map_id_map_id_fk": {
+          "name": "match_map_map_id_map_id_fk",
+          "tableFrom": "match_map",
+          "tableTo": "map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match_team": {
+      "name": "match_team",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_team_match_id_match_id_fk": {
+          "name": "match_team_match_id_match_id_fk",
+          "tableFrom": "match_team",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_team_team_id_teams_id_fk": {
+          "name": "match_team_team_id_teams_id_fk",
+          "tableFrom": "match_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_team_match_id_team_id_pk": {
+          "columns": [
+            "match_id",
+            "team_id"
+          ],
+          "name": "match_team_match_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "position": {
+          "name": "position",
+          "value": "\"match_team\".\"position\" >= 0"
+        }
+      }
+    },
+    "event_stage": {
+      "name": "event_stage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_stage_event": {
+          "name": "idx_stage_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_stage_event_id_event_id_fk": {
+          "name": "event_stage_event_id_event_id_fk",
+          "tableFrom": "event_stage",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "stage": {
+          "name": "stage",
+          "value": "\"event_stage\".\"stage\" IN ('group', 'qualifier', 'showmatch', 'playoff')"
+        },
+        "format": {
+          "name": "format",
+          "value": "\"event_stage\".\"format\" IN ('single', 'double', 'swiss', 'round-robin')"
+        }
+      }
+    },
+    "stage_node": {
+      "name": "stage_node",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_node_stage_id_event_stage_id_fk": {
+          "name": "stage_node_stage_id_event_stage_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "event_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_match_id_match_id_fk": {
+          "name": "stage_node_match_id_match_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_round_id_stage_round_id_fk": {
+          "name": "stage_node_round_id_stage_round_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "stage_round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stage_node_dependency": {
+      "name": "stage_node_dependency",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependency_match_id": {
+          "name": "dependency_match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_node_dependency_node_id_stage_node_id_fk": {
+          "name": "stage_node_dependency_node_id_stage_node_id_fk",
+          "tableFrom": "stage_node_dependency",
+          "tableTo": "stage_node",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_dependency_dependency_match_id_match_id_fk": {
+          "name": "stage_node_dependency_dependency_match_id_match_id_fk",
+          "tableFrom": "stage_node_dependency",
+          "tableTo": "match",
+          "columnsFrom": [
+            "dependency_match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stage_round": {
+      "name": "stage_round",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bracket": {
+          "name": "bracket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_group": {
+          "name": "parallel_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_round_stage_id_event_stage_id_fk": {
+          "name": "stage_round_stage_id_event_stage_id_fk",
+          "tableFrom": "stage_round",
+          "tableTo": "event_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_mouse_settings": {
+      "name": "player_mouse_settings",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dpi": {
+          "name": "dpi",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitivity": {
+          "name": "sensitivity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "polling_rate_hz": {
+          "name": "polling_rate_hz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "windows_pointer_speed": {
+          "name": "windows_pointer_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mouse_smoothing": {
+          "name": "mouse_smoothing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mouse_model": {
+          "name": "mouse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vertical_sens_multiplier": {
+          "name": "vertical_sens_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shoulder_fire_sens_multiplier": {
+          "name": "shoulder_fire_sens_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_1_25x": {
+          "name": "ads_sens_1_25x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_1_5x": {
+          "name": "ads_sens_1_5x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_2_5x": {
+          "name": "ads_sens_2_5x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_4_0x": {
+          "name": "ads_sens_4_0x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_mouse_settings_player_id_player_id_fk": {
+          "name": "player_mouse_settings_player_id_player_id_fk",
+          "tableFrom": "player_mouse_settings",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_character_stats": {
+      "name": "player_character_stats",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "superstring_power": {
+          "name": "superstring_power",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_game_at": {
+          "name": "last_game_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_pcs_player": {
+          "name": "idx_pcs_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcs_character": {
+          "name": "idx_pcs_character",
+          "columns": [
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcs_player_total_games": {
+          "name": "idx_pcs_player_total_games",
+          "columns": [
+            "player_id",
+            "total_games",
+            "superstring_power",
+            "total_wins"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_character_stats_player_id_player_id_fk": {
+          "name": "player_character_stats_player_id_player_id_fk",
+          "tableFrom": "player_character_stats",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "player_character_stats_character_id_character_id_fk": {
+          "name": "player_character_stats_character_id_character_id_fk",
+          "tableFrom": "player_character_stats",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_character_stats_player_id_character_id_pk": {
+          "columns": [
+            "player_id",
+            "character_id"
+          ],
+          "name": "player_character_stats_player_id_character_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_character_stats_history": {
+      "name": "player_character_stats_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superstring_power": {
+          "name": "superstring_power",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_pcsh_player": {
+          "name": "idx_pcsh_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_character": {
+          "name": "idx_pcsh_character",
+          "columns": [
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_snapshot": {
+          "name": "idx_pcsh_snapshot",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_player_character": {
+          "name": "idx_pcsh_player_character",
+          "columns": [
+            "player_id",
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_player_snapshot": {
+          "name": "idx_pcsh_player_snapshot",
+          "columns": [
+            "player_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_character_stats_history_player_id_player_id_fk": {
+          "name": "player_character_stats_history_player_id_player_id_fk",
+          "tableFrom": "player_character_stats_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "player_character_stats_history_character_id_character_id_fk": {
+          "name": "player_character_stats_history_character_id_character_id_fk",
+          "tableFrom": "player_character_stats_history",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_stats": {
+      "name": "player_stats",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "player_rating": {
+          "name": "player_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "events_count": {
+          "name": "events_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_game_at": {
+          "name": "last_game_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_stats_player_id_player_id_fk": {
+          "name": "player_stats_player_id_player_id_fk",
+          "tableFrom": "player_stats",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_stats_history": {
+      "name": "player_stats_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_rating": {
+          "name": "player_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events_count": {
+          "name": "events_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_psh_player": {
+          "name": "idx_psh_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psh_snapshot": {
+          "name": "idx_psh_snapshot",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_psh_player_snapshot": {
+          "name": "idx_psh_player_snapshot",
+          "columns": [
+            "player_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_stats_history_player_id_player_id_fk": {
+          "name": "player_stats_history_player_id_player_id_fk",
+          "tableFrom": "player_stats_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "edit_history": {
+      "name": "edit_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_eh_table": {
+          "name": "idx_eh_table",
+          "columns": [
+            "table_name"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_record": {
+          "name": "idx_eh_record",
+          "columns": [
+            "record_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_edited_by": {
+          "name": "idx_eh_edited_by",
+          "columns": [
+            "edited_by"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_edited_at": {
+          "name": "idx_eh_edited_at",
+          "columns": [
+            "edited_at"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_table_record": {
+          "name": "idx_eh_table_record",
+          "columns": [
+            "table_name",
+            "record_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_table_edited_at": {
+          "name": "idx_eh_table_edited_at",
+          "columns": [
+            "table_name",
+            "edited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edit_history_edited_by_user_id_fk": {
+          "name": "edit_history_edited_by_user_id_fk",
+          "tableFrom": "edit_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_tag": {
+      "name": "community_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_ct_category": {
+          "name": "idx_ct_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_ct_category_value": {
+          "name": "idx_ct_category_value",
+          "columns": [
+            "category",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discord_server": {
+      "name": "discord_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "additional_link_text": {
+          "name": "additional_link_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_link_url": {
+          "name": "additional_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discord_server_tag": {
+      "name": "discord_server_tag",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_dst_server": {
+          "name": "idx_dst_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        },
+        "idx_dst_tag": {
+          "name": "idx_dst_tag",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "discord_server_tag_server_id_discord_server_id_fk": {
+          "name": "discord_server_tag_server_id_discord_server_id_fk",
+          "tableFrom": "discord_server_tag",
+          "tableTo": "discord_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discord_server_tag_tag_id_community_tag_id_fk": {
+          "name": "discord_server_tag_tag_id_community_tag_id_fk",
+          "tableFrom": "discord_server_tag",
+          "tableTo": "community_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "discord_server_tag_server_id_tag_id_pk": {
+          "columns": [
+            "server_id",
+            "tag_id"
+          ],
+          "name": "discord_server_tag_server_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780168545805,
       "tag": "0000_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1780171910052,
+      "tag": "0001_empty_zzzax",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schemas/auth/index.ts
+++ b/src/lib/server/db/schemas/auth/index.ts
@@ -2,3 +2,5 @@ export * from './user';
 export * from './session';
 export * from './password-reset';
 export * from './mcp-token';
+export * from './mcp-audit-log';
+export * from './mcp-rate-limit';

--- a/src/lib/server/db/schemas/auth/mcp-audit-log.ts
+++ b/src/lib/server/db/schemas/auth/mcp-audit-log.ts
@@ -1,0 +1,50 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+import { user } from './user';
+import { mcpToken } from './mcp-token';
+
+/**
+ * Audit trail for the authorized MCP server.
+ *
+ * `edit_history` already records successful data mutations; this captures what
+ * it can't — every MCP tool call's outcome including reads, permission denials,
+ * rate-limit rejections, and errors — keyed by the token and its owner, so
+ * AI-driven access can be moderated and abuse traced to a revocable token.
+ */
+export const mcpAuditLog = sqliteTable(
+	'mcp_audit_log',
+	{
+		id: text('id').primaryKey(),
+		tokenId: text('token_id')
+			.notNull()
+			.references(() => mcpToken.id, { onDelete: 'cascade' }),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id),
+		tool: text('tool').notNull(),
+		status: text('status', { enum: ['success', 'denied', 'error', 'rate_limited'] }).notNull(),
+		detail: text('detail'),
+		ip: text('ip'),
+		createdAt: integer('created_at', { mode: 'timestamp' }).notNull()
+	},
+	(table) => {
+		return {
+			idx_token: index('idx_mcp_audit_token').on(table.tokenId),
+			idx_created: index('idx_mcp_audit_created').on(table.createdAt)
+		};
+	}
+);
+
+export type McpAuditLog = typeof mcpAuditLog.$inferSelect;
+export type NewMcpAuditLog = typeof mcpAuditLog.$inferInsert;
+
+export const mcpAuditLogRelations = relations(mcpAuditLog, ({ one }) => ({
+	token: one(mcpToken, {
+		fields: [mcpAuditLog.tokenId],
+		references: [mcpToken.id]
+	}),
+	user: one(user, {
+		fields: [mcpAuditLog.userId],
+		references: [user.id]
+	})
+}));

--- a/src/lib/server/db/schemas/auth/mcp-rate-limit.ts
+++ b/src/lib/server/db/schemas/auth/mcp-rate-limit.ts
@@ -1,0 +1,28 @@
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+import { relations } from 'drizzle-orm';
+import { mcpToken } from './mcp-token';
+
+/**
+ * Per-token rate-limit state (token-bucket) for the MCP server.
+ *
+ * One row per MCP token. `tokens` is the current number of available requests;
+ * it refills over time up to a capacity. Persisted (rather than in-memory) so
+ * the limit holds across serverless instances. See `src/lib/server/mcp/rate-limit.ts`.
+ */
+export const mcpRateLimit = sqliteTable('mcp_rate_limit', {
+	tokenId: text('token_id')
+		.primaryKey()
+		.references(() => mcpToken.id, { onDelete: 'cascade' }),
+	tokens: real('tokens').notNull(),
+	updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull()
+});
+
+export type McpRateLimit = typeof mcpRateLimit.$inferSelect;
+export type NewMcpRateLimit = typeof mcpRateLimit.$inferInsert;
+
+export const mcpRateLimitRelations = relations(mcpRateLimit, ({ one }) => ({
+	token: one(mcpToken, {
+		fields: [mcpRateLimit.tokenId],
+		references: [mcpToken.id]
+	})
+}));

--- a/src/lib/server/mcp/dispatch.test.ts
+++ b/src/lib/server/mcp/dispatch.test.ts
@@ -4,7 +4,8 @@ import {
 	MCP_PROTOCOL_VERSION,
 	type JsonRpcRequest,
 	type McpTool,
-	type McpIdentity
+	type McpIdentity,
+	type McpHooks
 } from './dispatch';
 
 const readTool: McpTool = {
@@ -34,8 +35,18 @@ const throwingTool: McpTool = {
 };
 
 const TOOLS = [readTool, writeTool, throwingTool];
-const reader: McpIdentity = { userId: 'u-read', username: 'reader', canWrite: false };
-const writer: McpIdentity = { userId: 'u-write', username: 'writer', canWrite: true };
+const reader: McpIdentity = {
+	tokenId: 't-read',
+	userId: 'u-read',
+	username: 'reader',
+	canWrite: false
+};
+const writer: McpIdentity = {
+	tokenId: 't-write',
+	userId: 'u-write',
+	username: 'writer',
+	canWrite: true
+};
 
 interface RpcResponse {
 	jsonrpc: string;
@@ -51,15 +62,15 @@ interface RpcResponse {
 	error?: { code: number; message: string };
 }
 
-async function rpc(
-	message: JsonRpcRequest,
-	identity: McpIdentity = reader
-): Promise<RpcResponse> {
+async function rpc(message: JsonRpcRequest, identity: McpIdentity = reader): Promise<RpcResponse> {
 	return (await dispatch(message, identity, TOOLS)) as unknown as RpcResponse;
 }
 
-const call = (id: number | string | null | undefined, method: string, params?: Record<string, unknown>) =>
-	rpc({ jsonrpc: '2.0', id, method, params });
+const call = (
+	id: number | string | null | undefined,
+	method: string,
+	params?: Record<string, unknown>
+) => rpc({ jsonrpc: '2.0', id, method, params });
 
 describe('dispatch — protocol', () => {
 	it('initialize advertises the protocol version, tool capability and server info', async () => {
@@ -152,5 +163,76 @@ describe('dispatch — tools/call', () => {
 		});
 		expect(res.result?.isError).toBe(true);
 		expect(res.result!.content![0].text).toContain('kaboom');
+	});
+});
+
+describe('dispatch — hooks (rate limit + audit)', () => {
+	type AuditEntry = { tool: string; status: string; detail?: string };
+
+	function makeHooks(allowed: boolean): { hooks: McpHooks; audits: AuditEntry[] } {
+		const audits: AuditEntry[] = [];
+		const hooks: McpHooks = {
+			rateLimit: async () => ({ allowed, retryAfterSeconds: allowed ? 0 : 7 }),
+			audit: async (entry) => {
+				audits.push(entry);
+			}
+		};
+		return { hooks, audits };
+	}
+
+	const callTool = (name: string, id: McpIdentity, hooks: McpHooks) =>
+		dispatch(
+			{ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name } },
+			id,
+			TOOLS,
+			hooks
+		) as Promise<RpcResponse>;
+
+	it('blocks the call and audits when the rate limiter denies', async () => {
+		const { hooks, audits } = makeHooks(false);
+		const res = await callTool('echo', reader, hooks);
+		expect(res.result?.isError).toBe(true);
+		expect(res.result!.content![0].text).toContain('rate limit exceeded');
+		expect(res.result!.content![0].text).toContain('7s');
+		expect(audits).toEqual([{ tool: 'echo', status: 'rate_limited', detail: 'retry after 7s' }]);
+	});
+
+	it('audits a successful tool call', async () => {
+		const { hooks, audits } = makeHooks(true);
+		const res = await callTool('echo', reader, hooks);
+		expect(res.result?.isError).toBeUndefined();
+		expect(audits).toEqual([{ tool: 'echo', status: 'success' }]);
+	});
+
+	it('audits a permission denial (and still consumes a rate-limit token)', async () => {
+		const calls: string[] = [];
+		const hooks: McpHooks = {
+			rateLimit: async () => {
+				calls.push('rateLimit');
+				return { allowed: true, retryAfterSeconds: 0 };
+			},
+			audit: async (e) => {
+				calls.push(`audit:${e.status}`);
+			}
+		};
+		const res = await callTool('mutate', reader, hooks); // reader can't write
+		expect(res.result?.isError).toBe(true);
+		expect(calls).toEqual(['rateLimit', 'audit:denied']);
+	});
+
+	it('audits a throwing handler as an error', async () => {
+		const { hooks, audits } = makeHooks(true);
+		await callTool('boom', reader, hooks);
+		expect(audits[0].status).toBe('error');
+		expect(audits[0].detail).toContain('kaboom');
+	});
+
+	it('works without hooks (back-compat)', async () => {
+		const res = (await dispatch(
+			{ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'echo', arguments: {} } },
+			reader,
+			TOOLS
+		)) as unknown as RpcResponse;
+		expect(res.result?.isError).toBeUndefined();
 	});
 });

--- a/src/lib/server/mcp/dispatch.ts
+++ b/src/lib/server/mcp/dispatch.ts
@@ -11,9 +11,22 @@ export const MCP_SERVER_INFO = { name: 'lemontv-mcp', version: '0.1.0' } as cons
 
 /** The authenticated caller, resolved from a Personal Access Token. */
 export interface McpIdentity {
+	tokenId: string;
 	userId: string;
 	username: string;
 	canWrite: boolean;
+}
+
+/** Audit/rate-limit side-effects, injected by the route (DB-backed in prod). */
+export interface McpHooks {
+	/** Consume one rate-limit token for this caller. */
+	rateLimit?: (identity: McpIdentity) => Promise<{ allowed: boolean; retryAfterSeconds: number }>;
+	/** Record the outcome of a tool call. */
+	audit?: (entry: {
+		tool: string;
+		status: 'success' | 'denied' | 'error' | 'rate_limited';
+		detail?: string;
+	}) => Promise<void>;
 }
 
 export interface JsonRpcRequest {
@@ -47,7 +60,8 @@ function rpcError(id: JsonRpcRequest['id'], code: number, message: string) {
 export async function dispatch(
 	message: JsonRpcRequest,
 	identity: McpIdentity,
-	tools: McpTool[]
+	tools: McpTool[],
+	hooks?: McpHooks
 ): Promise<object | null> {
 	if (!message || message.jsonrpc !== '2.0' || typeof message.method !== 'string') {
 		return rpcError(message?.id ?? null, -32600, 'Invalid Request');
@@ -87,8 +101,35 @@ export async function dispatch(
 			if (!tool) {
 				return rpcError(id, -32602, `Unknown tool: ${toolName}`);
 			}
+
+			// Rate limit every tool call (so even denied attempts cost a token).
+			if (hooks?.rateLimit) {
+				const rl = await hooks.rateLimit(identity);
+				if (!rl.allowed) {
+					await hooks.audit?.({
+						tool: toolName,
+						status: 'rate_limited',
+						detail: `retry after ${rl.retryAfterSeconds}s`
+					});
+					return rpcResult(id, {
+						content: [
+							{
+								type: 'text',
+								text: `Error: rate limit exceeded. Retry after ${rl.retryAfterSeconds}s.`
+							}
+						],
+						isError: true
+					});
+				}
+			}
+
 			// Deny-by-default: write tools require resolved write capability.
 			if (tool.requiresWrite && !identity.canWrite) {
+				await hooks?.audit?.({
+					tool: toolName,
+					status: 'denied',
+					detail: 'write permission required'
+				});
 				return rpcResult(id, {
 					content: [
 						{
@@ -99,14 +140,17 @@ export async function dispatch(
 					isError: true
 				});
 			}
+
 			try {
 				const result = await tool.handler(args, identity);
+				await hooks?.audit?.({ tool: toolName, status: 'success' });
 				return rpcResult(id, {
 					content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
 				});
 			} catch (error) {
 				const text = error instanceof Error ? error.message : 'Tool execution failed';
 				console.error(`[MCP] Tool "${toolName}" failed:`, error);
+				await hooks?.audit?.({ tool: toolName, status: 'error', detail: text });
 				return rpcResult(id, {
 					content: [{ type: 'text', text: `Error: ${text}` }],
 					isError: true

--- a/src/lib/server/mcp/hooks.ts
+++ b/src/lib/server/mcp/hooks.ts
@@ -1,0 +1,80 @@
+/**
+ * DB-backed implementations of the MCP dispatch hooks (audit + rate limit).
+ *
+ * The route composes these into an `McpHooks` object and passes it to
+ * `handleMcpMessage`; `dispatch` calls them around each `tools/call`.
+ */
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import { consumeToken, DEFAULT_BUCKET, type BucketState } from './rate-limit';
+
+/**
+ * Consume one rate-limit token for `tokenId` (persisted token bucket). Runs in
+ * a transaction so the read-modify-write is atomic per token.
+ */
+export async function consumeRateLimit(
+	tokenId: string
+): Promise<{ allowed: boolean; retryAfterSeconds: number }> {
+	const now = Date.now();
+	try {
+		return await db.transaction(async (tx) => {
+			const [row] = await tx
+				.select()
+				.from(table.mcpRateLimit)
+				.where(eq(table.mcpRateLimit.tokenId, tokenId));
+
+			const state: BucketState = row
+				? { tokens: row.tokens, updatedAtMs: row.updatedAt.getTime() }
+				: { tokens: DEFAULT_BUCKET.capacity, updatedAtMs: now };
+
+			const result = consumeToken(state, now, DEFAULT_BUCKET);
+
+			if (row) {
+				await tx
+					.update(table.mcpRateLimit)
+					.set({ tokens: result.tokens, updatedAt: new Date(now) })
+					.where(eq(table.mcpRateLimit.tokenId, tokenId));
+			} else {
+				await tx
+					.insert(table.mcpRateLimit)
+					.values({ tokenId, tokens: result.tokens, updatedAt: new Date(now) });
+			}
+
+			return { allowed: result.allowed, retryAfterSeconds: Math.ceil(result.retryAfterSeconds) };
+		});
+	} catch (error) {
+		// Fail open: a limiter glitch must not lock out trusted editors. Tokens
+		// are held by editors/admins (not anonymous), so availability wins here.
+		console.error('[MCP] Rate-limit check failed; allowing request', error);
+		return { allowed: true, retryAfterSeconds: 0 };
+	}
+}
+
+export interface McpAuditEntry {
+	tokenId: string;
+	userId: string;
+	tool: string;
+	status: 'success' | 'denied' | 'error' | 'rate_limited';
+	detail?: string | null;
+	ip?: string | null;
+}
+
+/** Append an audit row. Best-effort: never throws (auditing must not break the request). */
+export async function logMcpAudit(entry: McpAuditEntry): Promise<void> {
+	try {
+		await db.insert(table.mcpAuditLog).values({
+			id: randomUUID(),
+			tokenId: entry.tokenId,
+			userId: entry.userId,
+			tool: entry.tool,
+			status: entry.status,
+			detail: entry.detail ?? null,
+			ip: entry.ip ?? null,
+			createdAt: new Date()
+		});
+	} catch (error) {
+		console.error('[MCP] Failed to write audit log entry', error);
+	}
+}

--- a/src/lib/server/mcp/rate-limit.test.ts
+++ b/src/lib/server/mcp/rate-limit.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'bun:test';
+import {
+	consumeToken,
+	refilledTokens,
+	initialBucket,
+	DEFAULT_BUCKET,
+	type BucketConfig
+} from './rate-limit';
+
+const CFG: BucketConfig = { capacity: 10, refillPerSecond: 1 };
+const T0 = 1_000_000;
+
+describe('refilledTokens', () => {
+	it('replenishes by elapsed time at the refill rate', () => {
+		// 2 tokens, +5s at 1/s => 7
+		expect(refilledTokens({ tokens: 2, updatedAtMs: T0 }, T0 + 5000, CFG)).toBe(7);
+	});
+
+	it('never exceeds capacity', () => {
+		expect(refilledTokens({ tokens: 8, updatedAtMs: T0 }, T0 + 60_000, CFG)).toBe(CFG.capacity);
+	});
+
+	it('treats clock going backwards as zero elapsed', () => {
+		expect(refilledTokens({ tokens: 4, updatedAtMs: T0 }, T0 - 5000, CFG)).toBe(4);
+	});
+});
+
+describe('consumeToken', () => {
+	it('allows and decrements when tokens are available', () => {
+		const r = consumeToken({ tokens: 3, updatedAtMs: T0 }, T0, CFG);
+		expect(r.allowed).toBe(true);
+		expect(r.tokens).toBe(2);
+		expect(r.retryAfterSeconds).toBe(0);
+	});
+
+	it('denies when the bucket is empty and reports retry-after', () => {
+		const r = consumeToken({ tokens: 0, updatedAtMs: T0 }, T0, CFG);
+		expect(r.allowed).toBe(false);
+		expect(r.tokens).toBe(0);
+		// need 1 token at 1/s => 1s
+		expect(r.retryAfterSeconds).toBe(1);
+	});
+
+	it('allows again once enough time has elapsed to refill', () => {
+		const empty = { tokens: 0, updatedAtMs: T0 };
+		expect(consumeToken(empty, T0 + 500, CFG).allowed).toBe(false); // 0.5 tokens
+		expect(consumeToken(empty, T0 + 1000, CFG).allowed).toBe(true); // 1 token
+	});
+
+	it('a fresh bucket permits a full burst then denies', () => {
+		let state = initialBucket(T0, CFG);
+		let allowed = 0;
+		for (let i = 0; i < CFG.capacity + 3; i++) {
+			const r = consumeToken(state, T0, CFG);
+			if (r.allowed) allowed++;
+			state = { tokens: r.tokens, updatedAtMs: T0 };
+		}
+		expect(allowed).toBe(CFG.capacity);
+	});
+
+	it('uses the default bucket config when none is passed', () => {
+		const r = consumeToken({ tokens: DEFAULT_BUCKET.capacity, updatedAtMs: T0 }, T0);
+		expect(r.allowed).toBe(true);
+		expect(r.tokens).toBe(DEFAULT_BUCKET.capacity - 1);
+	});
+});

--- a/src/lib/server/mcp/rate-limit.ts
+++ b/src/lib/server/mcp/rate-limit.ts
@@ -1,0 +1,54 @@
+/**
+ * Token-bucket rate limiting — pure core.
+ *
+ * No DB/SvelteKit imports, so it is unit-testable in isolation. The persisted
+ * per-token state lives in `mcp_rate_limit`; the DB-backed `consumeRateLimit`
+ * (in `./hooks`) reads/writes a row and applies these functions.
+ */
+export interface BucketConfig {
+	/** Maximum tokens the bucket holds (the burst allowance). */
+	capacity: number;
+	/** Tokens replenished per second (the sustained rate). */
+	refillPerSecond: number;
+}
+
+export interface BucketState {
+	tokens: number;
+	updatedAtMs: number;
+}
+
+export interface ConsumeResult {
+	allowed: boolean;
+	/** Tokens remaining after this attempt (post-refill, post-decrement if allowed). */
+	tokens: number;
+	/** Seconds until the next token is available (0 when allowed). */
+	retryAfterSeconds: number;
+}
+
+/** Default: burst of 120 requests, sustained 2 requests/second per token. */
+export const DEFAULT_BUCKET: BucketConfig = { capacity: 120, refillPerSecond: 2 };
+
+/** Tokens available now, after replenishing for elapsed time (capped at capacity). */
+export function refilledTokens(state: BucketState, nowMs: number, config: BucketConfig): number {
+	const elapsedSeconds = Math.max(0, (nowMs - state.updatedAtMs) / 1000);
+	return Math.min(config.capacity, state.tokens + elapsedSeconds * config.refillPerSecond);
+}
+
+/** Attempt to consume one token. Pure — returns the next state without persisting. */
+export function consumeToken(
+	state: BucketState,
+	nowMs: number,
+	config: BucketConfig = DEFAULT_BUCKET
+): ConsumeResult {
+	const tokens = refilledTokens(state, nowMs, config);
+	if (tokens >= 1) {
+		return { allowed: true, tokens: tokens - 1, retryAfterSeconds: 0 };
+	}
+	const deficit = 1 - tokens;
+	return { allowed: false, tokens, retryAfterSeconds: deficit / config.refillPerSecond };
+}
+
+/** A fresh, full bucket. */
+export function initialBucket(nowMs: number, config: BucketConfig = DEFAULT_BUCKET): BucketState {
+	return { tokens: config.capacity, updatedAtMs: nowMs };
+}

--- a/src/lib/server/mcp/server.ts
+++ b/src/lib/server/mcp/server.ts
@@ -5,16 +5,17 @@
  * tool registry (./tools). The HTTP transport + authentication lives in the
  * SvelteKit route `src/routes/api/mcp/+server.ts`.
  */
-import { dispatch, type JsonRpcRequest, type McpIdentity } from './dispatch';
+import { dispatch, type JsonRpcRequest, type McpIdentity, type McpHooks } from './dispatch';
 import { TOOLS } from './tools';
 
 export { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from './dispatch';
-export type { McpIdentity } from './dispatch';
+export type { McpIdentity, McpHooks } from './dispatch';
 
 /** Handle one JSON-RPC message against the live tool registry. */
 export function handleMcpMessage(
 	message: JsonRpcRequest,
-	identity: McpIdentity
+	identity: McpIdentity,
+	hooks?: McpHooks
 ): Promise<object | null> {
-	return dispatch(message, identity, TOOLS);
+	return dispatch(message, identity, TOOLS, hooks);
 }

--- a/src/routes/api/mcp/+server.ts
+++ b/src/routes/api/mcp/+server.ts
@@ -66,9 +66,15 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	// JSON-RPC batch or single message.
 	if (Array.isArray(body)) {
-		const responses = (
-			await Promise.all(body.map((msg) => handleMcpMessage(msg as never, identity, hooks)))
-		).filter((r): r is object => r !== null);
+		// Process sequentially: parallel handling would let every message in a
+		// batch read the same rate-limit bucket before any decrement is written,
+		// so one large batch could run far above the per-token limit. Sequential
+		// processing serializes each consume → write before the next call.
+		const responses: object[] = [];
+		for (const msg of body) {
+			const r = await handleMcpMessage(msg as never, identity, hooks);
+			if (r !== null) responses.push(r);
+		}
 		return responses.length === 0 ? new Response(null, { status: 202 }) : json(responses);
 	}
 

--- a/src/routes/api/mcp/+server.ts
+++ b/src/routes/api/mcp/+server.ts
@@ -9,7 +9,8 @@
 import { json, error as kitError } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { validateMcpToken } from '$lib/server/security/mcp-token-store';
-import { handleMcpMessage, type McpIdentity } from '$lib/server/mcp/server';
+import { handleMcpMessage, type McpIdentity, type McpHooks } from '$lib/server/mcp/server';
+import { consumeRateLimit, logMcpAudit } from '$lib/server/mcp/hooks';
 
 function bearerToken(request: Request): string | null {
 	const header = request.headers.get('authorization');
@@ -40,9 +41,17 @@ export const POST: RequestHandler = async ({ request }) => {
 	}
 
 	const identity: McpIdentity = {
+		tokenId: validation.token.id,
 		userId: validation.user.id,
 		username: validation.user.username,
 		canWrite: validation.canWrite
+	};
+
+	const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
+	const hooks: McpHooks = {
+		rateLimit: (id) => consumeRateLimit(id.tokenId),
+		audit: (entry) =>
+			logMcpAudit({ ...entry, tokenId: identity.tokenId, userId: identity.userId, ip })
 	};
 
 	let body: unknown;
@@ -58,12 +67,12 @@ export const POST: RequestHandler = async ({ request }) => {
 	// JSON-RPC batch or single message.
 	if (Array.isArray(body)) {
 		const responses = (
-			await Promise.all(body.map((msg) => handleMcpMessage(msg as never, identity)))
+			await Promise.all(body.map((msg) => handleMcpMessage(msg as never, identity, hooks)))
 		).filter((r): r is object => r !== null);
 		return responses.length === 0 ? new Response(null, { status: 202 }) : json(responses);
 	}
 
-	const response = await handleMcpMessage(body as never, identity);
+	const response = await handleMcpMessage(body as never, identity, hooks);
 	return response === null ? new Response(null, { status: 202 }) : json(response);
 };
 


### PR DESCRIPTION
Hardens the authorized MCP server so AI-driven access is **observable and abuse-resistant**. This is the **first schema change to ship via the new migrations workflow** (#51) — a clean 2-table `0001` migration with **zero spurious rebuilds**.

## What
- **`mcp_audit_log`** — every tool call's outcome (`success` / `denied` / `error` / `rate_limited`) with token, user, tool, and IP. Moderatable and traceable to a revocable token. (Successful mutations also remain in `edit_history`.)
- **`mcp_rate_limit`** — persisted token bucket per token (burst 120, sustained 2/s), durable across serverless instances.
- **`rate-limit.ts`** — pure bucket math (refill/consume), unit-tested.
- **`hooks.ts`** — DB-backed `consumeRateLimit` (atomic per-token transaction; **fails open** on a DB glitch so trusted editors aren't locked out) + best-effort `logMcpAudit` (never throws).
- **`dispatch`** — optional `McpHooks`; `tools/call` now rate-limits (even denied attempts cost a token) then audits every outcome. Back-compat: no hooks → prior behavior. The route builds the DB-backed hooks and threads `tokenId` + IP.
- **`drizzle/0001`** — `CREATE mcp_audit_log` + `mcp_rate_limit` (+ indexes).

## Verification
- `bun run check` → **0 errors**
- `bun test src/` → **107 pass / 0 fail** (rate-limit math, dispatch hooks incl. deny/audit/error, back-compat)
- Fresh `db:dev:migrate` applies `0000`+`0001`; both new tables exist; **0 `__new_` rebuilds** in `0001`.

## Deploy note
`deploy` runs `db:prod:migrate` (creates these tables) **before** the Vercel deploy, so the live MCP server always has them. No manual prod step needed.

## Not in scope (follow-up)
- `/admin/mcp-log` viewer UI for the audit trail (data is queryable now; viewer is a separate, i18n'd UI PR).
- Write tools for teams/players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)