### PR TITLE
MCP: player & team read/create tools

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -32,11 +32,19 @@ endpoint above and set the same `Authorization` header.
 
 ## Tools
 
-| Tool           | Scope     | Purpose                                                           |
-| -------------- | --------- | ----------------------------------------------------------------- |
-| `list_events`  | read      | List tournaments/events (newest first); optional `status` filter. |
-| `get_event`    | read      | Fetch one event by `idOrSlug`.                                    |
-| `create_event` | **write** | Create a new tournament/event. Returns the new id.                |
+| Tool            | Scope     | Purpose                                                           |
+| --------------- | --------- | ----------------------------------------------------------------- |
+| `list_events`   | read      | List tournaments/events (newest first); optional `status` filter. |
+| `get_event`     | read      | Fetch one event by `idOrSlug`.                                    |
+| `create_event`  | **write** | Create a new tournament/event. Returns the new id.                |
+| `list_players`  | read      | List players; optional name/slug `search` + `limit`.              |
+| `get_player`    | read      | Fetch one player by id/slug/name (account PII omitted).           |
+| `create_player` | **write** | Create a player. Returns the new id.                              |
+| `list_teams`    | read      | List teams; optional `region` filter + `limit`.                   |
+| `get_team`      | read      | Fetch one team by id/slug incl. roster (account PII omitted).     |
+| `create_team`   | **write** | Create a team. Returns the new id.                                |
+
+Read tools strip account PII (`user.email`/`username`/linkage) from output.
 
 `create_event` arguments: `name`, `slug`, `server` (`calabiyau`\|`strinova`),
 `format` (`lan`\|`online`\|`hybrid`), `region`, `status`
@@ -44,6 +52,20 @@ endpoint above and set the same `Authorization` header.
 (`YYYY-MM-DD` or `YYYY-MM-DD/YYYY-MM-DD`), `image` (required — a placeholder URL
 is fine), plus optional `official`, `capacity`, `organizerIds`, `websites`.
 Teams, results, and casters are added separately (admin UI for now).
+
+`create_player` arguments: `name` (required), optional `slug`, `nationalities`
+(ISO codes; first is primary), `aliases`, `avatar`, `gameAccounts`
+(`{ accountId, currentName, region? }`), `socialAccounts`
+(`{ platformId, accountId, overridingUrl? }`).
+
+`create_team` arguments: `name` (required), optional `slug`, `abbr`, `region`
+(`CN`/`APAC`/`NA`/`SA`/`EU`/`WA`/`Global`), `logo`, `aliases`, `players`
+(`{ playerId, role, startedOn?, endedOn?, note? }`; `role` ∈
+`active`/`substitute`/`former`/`coach`/`manager`/`owner`), `slogans`.
+
+> **Editing/deleting** existing players & teams over MCP is intentionally not
+> exposed yet: the underlying update is a full-replacement of nested collections
+> (a safe merge-based `update_*` is a follow-up) and delete is a hard delete.
 
 ## Example: adding a tournament
 

--- a/src/lib/server/mcp/args.test.ts
+++ b/src/lib/server/mcp/args.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'bun:test';
-import { requireString } from './args';
+import { requireString, optionalEnum } from './args';
+
+describe('optionalEnum', () => {
+	const REGIONS = ['CN', 'APAC', 'NA', 'EU'] as const;
+
+	it('returns undefined for absent values', () => {
+		expect(optionalEnum(undefined, REGIONS, 'region')).toBeUndefined();
+		expect(optionalEnum(null, REGIONS, 'region')).toBeUndefined();
+	});
+
+	it('returns the value when it is in the allowed set', () => {
+		expect(optionalEnum('APAC', REGIONS, 'region')).toBe('APAC');
+	});
+
+	it('throws on a value outside the allowed set', () => {
+		expect(() => optionalEnum('MARS', REGIONS, 'region')).toThrow('Invalid region');
+		expect(() => optionalEnum('apac', REGIONS, 'region')).toThrow(); // case-sensitive
+		expect(() => optionalEnum(7, REGIONS, 'region')).toThrow();
+	});
+});
 
 describe('requireString', () => {
 	it('returns the value for a valid non-empty string', () => {

--- a/src/lib/server/mcp/args.test.ts
+++ b/src/lib/server/mcp/args.test.ts
@@ -1,5 +1,42 @@
 import { describe, it, expect } from 'bun:test';
-import { requireString, optionalEnum } from './args';
+import { requireString, requireInt, optionalEnum, requireEnum } from './args';
+
+describe('requireEnum', () => {
+	const ROLES = ['active', 'substitute', 'coach'] as const;
+
+	it('returns a valid value', () => {
+		expect(requireEnum('coach', ROLES, 'role')).toBe('coach');
+	});
+
+	it('throws (never defaults) when absent or misspelled', () => {
+		expect(() => requireEnum(undefined, ROLES, 'role')).toThrow('role');
+		expect(() => requireEnum('actve', ROLES, 'role')).toThrow();
+		expect(() => requireEnum('Active', ROLES, 'role')).toThrow(); // case-sensitive
+		expect(() => requireEnum(null, ROLES, 'role')).toThrow();
+	});
+});
+
+describe('requireInt', () => {
+	it('returns integer numbers and numeric strings', () => {
+		expect(requireInt({ accountId: 12345 }, 'accountId')).toBe(12345);
+		expect(requireInt({ accountId: '6789' }, 'accountId')).toBe(6789);
+		expect(requireInt({ accountId: 0 }, 'accountId')).toBe(0);
+	});
+
+	it('rejects null/undefined/missing (the Number(null)=0 footgun)', () => {
+		expect(() => requireInt({ accountId: null }, 'accountId')).toThrow('accountId');
+		expect(() => requireInt({ accountId: undefined }, 'accountId')).toThrow();
+		expect(() => requireInt({}, 'accountId')).toThrow();
+	});
+
+	it('rejects non-integer / non-numeric values', () => {
+		expect(() => requireInt({ accountId: 12.5 }, 'accountId')).toThrow();
+		expect(() => requireInt({ accountId: 'abc' }, 'accountId')).toThrow();
+		expect(() => requireInt({ accountId: '' }, 'accountId')).toThrow();
+		expect(() => requireInt({ accountId: NaN }, 'accountId')).toThrow();
+		expect(() => requireInt({ accountId: true }, 'accountId')).toThrow();
+	});
+});
 
 describe('optionalEnum', () => {
 	const REGIONS = ['CN', 'APAC', 'NA', 'EU'] as const;

--- a/src/lib/server/mcp/args.ts
+++ b/src/lib/server/mcp/args.ts
@@ -18,3 +18,20 @@ export function requireString(args: Record<string, unknown>, key: string): strin
 	}
 	return value;
 }
+
+/**
+ * Validate an optional enum argument. Returns `undefined` when absent, the value
+ * when it's one of `allowed`, and throws otherwise — the data layer stores these
+ * as plain text without validating, so the tool must.
+ */
+export function optionalEnum<T extends string>(
+	value: unknown,
+	allowed: readonly T[],
+	field: string
+): T | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value === 'string' && (allowed as readonly string[]).includes(value)) {
+		return value as T;
+	}
+	throw new Error(`Invalid ${field}: expected one of ${allowed.join(', ')}`);
+}

--- a/src/lib/server/mcp/args.ts
+++ b/src/lib/server/mcp/args.ts
@@ -20,6 +20,26 @@ export function requireString(args: Record<string, unknown>, key: string): strin
 }
 
 /**
+ * Read a required integer argument. Accepts a number or a numeric string and
+ * rejects missing/null/NaN/non-integer values — without this, `Number(null)`
+ * would coerce to `0` and create a corrupt record (game accounts are keyed by
+ * account id).
+ */
+export function requireInt(args: Record<string, unknown>, key: string): number {
+	const value = args[key];
+	const n =
+		typeof value === 'number'
+			? value
+			: typeof value === 'string' && value.trim() !== ''
+				? Number(value)
+				: NaN;
+	if (!Number.isFinite(n) || !Number.isInteger(n)) {
+		throw new Error(`Missing or invalid required field: ${key} (expected an integer)`);
+	}
+	return n;
+}
+
+/**
  * Validate an optional enum argument. Returns `undefined` when absent, the value
  * when it's one of `allowed`, and throws otherwise — the data layer stores these
  * as plain text without validating, so the tool must.
@@ -34,4 +54,22 @@ export function optionalEnum<T extends string>(
 		return value as T;
 	}
 	throw new Error(`Invalid ${field}: expected one of ${allowed.join(', ')}`);
+}
+
+/**
+ * Validate a required enum argument — throws when absent or not in `allowed`
+ * (never silently defaults), so a missing/misspelled value surfaces as a bad
+ * request instead of being coerced to a wrong-but-valid option.
+ */
+export function requireEnum<T extends string>(
+	value: unknown,
+	allowed: readonly T[],
+	field: string
+): T {
+	if (typeof value === 'string' && (allowed as readonly string[]).includes(value)) {
+		return value as T;
+	}
+	throw new Error(
+		`Missing or invalid required field: ${field} (expected one of ${allowed.join(', ')})`
+	);
 }

--- a/src/lib/server/mcp/project.test.ts
+++ b/src/lib/server/mcp/project.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'bun:test';
+import { stripUser, stripRosterUserPII } from './project';
+
+describe('stripUser', () => {
+	it('removes the user account object (email/username/linkage)', () => {
+		const player = {
+			id: 'p1',
+			name: 'Alice',
+			user: { id: 'u1', email: 'a@example.com', username: 'alice', roles: ['editor'] }
+		};
+		const out = stripUser(player);
+		expect('user' in out).toBe(false);
+		expect(out).toEqual({ id: 'p1', name: 'Alice' });
+	});
+
+	it('is a no-op when there is no user field', () => {
+		expect(stripUser({ id: 'p1', name: 'Bob' })).toEqual({ id: 'p1', name: 'Bob' });
+	});
+
+	it('does not mutate the input', () => {
+		const player = { id: 'p1', user: { email: 'a@example.com' } };
+		stripUser(player);
+		expect(player.user).toBeDefined();
+	});
+});
+
+describe('stripRosterUserPII', () => {
+	it('strips user from each roster entry player', () => {
+		const team = {
+			id: 't1',
+			name: 'Team',
+			players: [
+				{ role: 'active', player: { id: 'p1', name: 'A', user: { email: 'a@x.com' } } },
+				{ role: 'sub', player: { id: 'p2', name: 'B', user: { email: 'b@x.com' } } }
+			]
+		};
+		const out = stripRosterUserPII(team);
+		const roster = out.players as { player: Record<string, unknown> }[];
+		for (const entry of roster) {
+			expect('user' in entry.player).toBe(false);
+		}
+		expect(roster[0].player).toEqual({ id: 'p1', name: 'A' });
+	});
+
+	it('handles a team with no players', () => {
+		expect(stripRosterUserPII({ id: 't1', name: 'Team' })).toEqual({ id: 't1', name: 'Team' });
+	});
+
+	it('tolerates roster entries without a player object', () => {
+		const team = { id: 't1', players: [{ role: 'active' }] };
+		expect(stripRosterUserPII(team)).toEqual(team);
+	});
+});

--- a/src/lib/server/mcp/project.ts
+++ b/src/lib/server/mcp/project.ts
@@ -1,0 +1,31 @@
+/**
+ * PII projection for MCP read-tool output.
+ *
+ * The data-layer getters (`getPlayer`, `getTeam`, …) join the `user` table and
+ * include `user.email`, `user.username`, and the player↔account linkage. None of
+ * that may go over MCP, so read tools project it away. Kept DB-free and
+ * unit-tested — this is a security boundary.
+ */
+type Rec = Record<string, unknown>;
+
+/** Remove the joined `user` account object (email/username/linkage) from a record. */
+export function stripUser(record: Rec): Rec {
+	const clone = { ...record };
+	delete clone.user;
+	return clone;
+}
+
+/** Strip `user` PII from every roster entry's nested `player` on a team object. */
+export function stripRosterUserPII(team: Rec): Rec {
+	if (!Array.isArray(team.players)) return team;
+	const players = team.players.map((entry) => {
+		if (entry && typeof entry === 'object' && 'player' in entry) {
+			const e = entry as Rec;
+			if (e.player && typeof e.player === 'object') {
+				return { ...e, player: stripUser(e.player as Rec) };
+			}
+		}
+		return entry;
+	});
+	return { ...team, players };
+}

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -15,7 +15,7 @@ import { createTeam, getTeam, getTeams } from '$lib/server/data/teams';
 import { getGameAccountServer } from '$lib/data/players';
 import { formatSlug } from '$lib/utils/strings';
 import type { McpTool } from './dispatch';
-import { requireString, optionalEnum } from './args';
+import { requireString, requireInt, optionalEnum, requireEnum } from './args';
 import { stripUser, stripRosterUserPII } from './project';
 
 const GAME_ACCOUNT_REGIONS = ['APAC', 'NA', 'EU', 'CN'] as const;
@@ -286,15 +286,15 @@ export const TOOLS: McpTool[] = [
 				const region = optionalEnum(a.region, GAME_ACCOUNT_REGIONS, 'gameAccounts.region');
 				return {
 					server: getGameAccountServer(region),
-					accountId: Number(a.accountId),
-					currentName: String(a.currentName ?? ''),
+					accountId: requireInt(a, 'accountId'),
+					currentName: requireString(a, 'currentName'),
 					region
 				};
 			});
 			const socialAccounts = Array.isArray(args.socialAccounts)
 				? (args.socialAccounts as Record<string, unknown>[]).map((a) => ({
-						platformId: String(a.platformId),
-						accountId: String(a.accountId),
+						platformId: requireString(a, 'platformId'),
+						accountId: requireString(a, 'accountId'),
 						overridingUrl: typeof a.overridingUrl === 'string' ? a.overridingUrl : undefined
 					}))
 				: undefined;
@@ -419,7 +419,7 @@ export const TOOLS: McpTool[] = [
 			const players = Array.isArray(args.players)
 				? (args.players as Record<string, unknown>[]).map((p) => ({
 						playerId: requireString(p, 'playerId'),
-						role: optionalEnum(p.role, TEAM_PLAYER_ROLES, 'players.role') ?? 'active',
+						role: requireEnum(p.role, TEAM_PLAYER_ROLES, 'players.role'),
 						startedOn: typeof p.startedOn === 'string' ? p.startedOn : undefined,
 						endedOn: typeof p.endedOn === 'string' ? p.endedOn : undefined,
 						note: typeof p.note === 'string' ? p.note : undefined

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -6,11 +6,21 @@
  * are flagged `requiresWrite` and enforced by `dispatch`.
  */
 import { desc, eq, or } from 'drizzle-orm';
+import type { TCountryCode } from 'countries-list';
 import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { createEvent, EVENT_FORMATS, EVENT_SERVERS, EVENT_STATUSES } from '$lib/server/data/events';
+import { createPlayer, getPlayer, getPlayers } from '$lib/server/data/players';
+import { createTeam, getTeam, getTeams } from '$lib/server/data/teams';
+import { getGameAccountServer } from '$lib/data/players';
+import { formatSlug } from '$lib/utils/strings';
 import type { McpTool } from './dispatch';
-import { requireString } from './args';
+import { requireString, optionalEnum } from './args';
+import { stripUser, stripRosterUserPII } from './project';
+
+const GAME_ACCOUNT_REGIONS = ['APAC', 'NA', 'EU', 'CN'] as const;
+const TEAM_REGIONS = ['CN', 'APAC', 'NA', 'SA', 'EU', 'WA', 'Global'] as const;
+const TEAM_PLAYER_ROLES = ['active', 'substitute', 'former', 'coach', 'manager', 'owner'] as const;
 
 const EVENT_SUMMARY_COLUMNS = {
 	id: table.event.id,
@@ -157,6 +167,285 @@ export const TOOLS: McpTool[] = [
 				},
 				identity.userId,
 				{ source: 'mcp:create_event' }
+			);
+			return { id, slug, created: true };
+		}
+	},
+	{
+		name: 'list_players',
+		description:
+			'List LemonTV players (id, slug, name, nationalities, aliases, avatar). Optional case-insensitive name/slug filter and limit. No account PII.',
+		requiresWrite: false,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				search: {
+					type: 'string',
+					description: 'Case-insensitive substring matched on name and slug.'
+				},
+				limit: {
+					type: 'integer',
+					minimum: 1,
+					maximum: 500,
+					description: 'Max players (default 100).'
+				}
+			},
+			additionalProperties: false
+		},
+		handler: async (args) => {
+			const search = typeof args.search === 'string' ? args.search.toLowerCase() : null;
+			const limit = Math.min(Math.max(Number(args.limit) || 100, 1), 500);
+			let players = await getPlayers();
+			if (search) {
+				players = players.filter(
+					(p) => p.name.toLowerCase().includes(search) || p.slug.toLowerCase().includes(search)
+				);
+			}
+			const items = players.slice(0, limit).map((p) => ({
+				id: p.id,
+				slug: p.slug,
+				name: p.name,
+				nationalities: p.nationalities,
+				aliases: p.aliases,
+				avatar: p.avatar ?? null
+			}));
+			return { count: items.length, players: items };
+		}
+	},
+	{
+		name: 'get_player',
+		description:
+			'Get a LemonTV player by id, slug, or name. Account PII (email/username/user linkage) is omitted.',
+		requiresWrite: false,
+		inputSchema: {
+			type: 'object',
+			properties: { idOrSlug: { type: 'string', description: 'Player id, slug, or name.' } },
+			required: ['idOrSlug'],
+			additionalProperties: false
+		},
+		handler: async (args) => {
+			const player = await getPlayer(requireString(args, 'idOrSlug'));
+			return player ? stripUser(player as unknown as Record<string, unknown>) : null;
+		}
+	},
+	{
+		name: 'create_player',
+		description:
+			'Create a new LemonTV player. Returns the new player id. Pass the COMPLETE set of nationalities/aliases/gameAccounts/socialAccounts (they are stored as given, not merged). Attributed to the token owner.',
+		requiresWrite: true,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				name: { type: 'string', description: 'Display name.' },
+				slug: { type: 'string', description: 'URL slug; defaults to a slug of the name.' },
+				nationalities: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'ISO country codes; the first is the primary nationality.'
+				},
+				aliases: { type: 'array', items: { type: 'string' } },
+				avatar: { type: 'string', description: 'Avatar image URL/key.' },
+				gameAccounts: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							accountId: { type: 'integer' },
+							currentName: { type: 'string' },
+							region: { type: 'string', enum: [...GAME_ACCOUNT_REGIONS] }
+						},
+						required: ['accountId', 'currentName'],
+						additionalProperties: false
+					},
+					description: 'In-game accounts; server is derived from region.'
+				},
+				socialAccounts: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							platformId: { type: 'string' },
+							accountId: { type: 'string' },
+							overridingUrl: { type: 'string' }
+						},
+						required: ['platformId', 'accountId'],
+						additionalProperties: false
+					}
+				}
+			},
+			required: ['name'],
+			additionalProperties: false
+		},
+		handler: async (args, identity) => {
+			const name = requireString(args, 'name');
+			const slug =
+				typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : formatSlug(name);
+			const gameAccounts = (
+				Array.isArray(args.gameAccounts) ? (args.gameAccounts as Record<string, unknown>[]) : []
+			).map((a) => {
+				const region = optionalEnum(a.region, GAME_ACCOUNT_REGIONS, 'gameAccounts.region');
+				return {
+					server: getGameAccountServer(region),
+					accountId: Number(a.accountId),
+					currentName: String(a.currentName ?? ''),
+					region
+				};
+			});
+			const socialAccounts = Array.isArray(args.socialAccounts)
+				? (args.socialAccounts as Record<string, unknown>[]).map((a) => ({
+						platformId: String(a.platformId),
+						accountId: String(a.accountId),
+						overridingUrl: typeof a.overridingUrl === 'string' ? a.overridingUrl : undefined
+					}))
+				: undefined;
+			const id = await createPlayer(
+				{
+					name,
+					slug,
+					nationalities: (Array.isArray(args.nationalities)
+						? (args.nationalities as string[])
+						: []) as TCountryCode[],
+					aliases: Array.isArray(args.aliases) ? (args.aliases as string[]) : [],
+					avatar: typeof args.avatar === 'string' ? args.avatar : undefined,
+					gameAccounts,
+					socialAccounts
+				},
+				identity.userId
+			);
+			return { id, slug, created: true };
+		}
+	},
+	{
+		name: 'list_teams',
+		description:
+			'List LemonTV teams (id, slug, name, abbr, region, logo, wins, aliases). Optional region filter and limit. No account PII.',
+		requiresWrite: false,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				region: { type: 'string', enum: [...TEAM_REGIONS] },
+				limit: {
+					type: 'integer',
+					minimum: 1,
+					maximum: 500,
+					description: 'Max teams (default 100).'
+				}
+			},
+			additionalProperties: false
+		},
+		handler: async (args) => {
+			const region = optionalEnum(args.region, TEAM_REGIONS, 'region');
+			const limit = Math.min(Math.max(Number(args.limit) || 100, 1), 500);
+			let teams = await getTeams();
+			if (region) teams = teams.filter((t) => t.region === region);
+			const items = teams.slice(0, limit).map((t) => ({
+				id: t.id,
+				slug: t.slug,
+				name: t.name,
+				abbr: t.abbr,
+				region: t.region,
+				logo: t.logoURL ?? t.logo ?? null,
+				wins: t.wins ?? null,
+				aliases: t.aliases ?? []
+			}));
+			return { count: items.length, teams: items };
+		}
+	},
+	{
+		name: 'get_team',
+		description:
+			'Get a LemonTV team by id or slug, including roster, aliases, region and logo. Account PII on roster players is omitted.',
+		requiresWrite: false,
+		inputSchema: {
+			type: 'object',
+			properties: { idOrSlug: { type: 'string', description: 'Team id or slug.' } },
+			required: ['idOrSlug'],
+			additionalProperties: false
+		},
+		handler: async (args) => {
+			const team = await getTeam(requireString(args, 'idOrSlug'));
+			return team ? stripRosterUserPII(team as unknown as { players?: unknown }) : null;
+		}
+	},
+	{
+		name: 'create_team',
+		description:
+			'Create a new LemonTV team. Requires name. Returns the new team id. Roster players (need existing player ids), aliases, and slogans are optional. Attributed to the token owner.',
+		requiresWrite: true,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				name: { type: 'string' },
+				slug: { type: 'string', description: 'Defaults to a slug of the name.' },
+				abbr: { type: 'string', description: 'Short tag, e.g. "MMR".' },
+				region: { type: 'string', enum: [...TEAM_REGIONS] },
+				logo: { type: 'string', description: 'Logo image URL/key.' },
+				aliases: { type: 'array', items: { type: 'string' } },
+				players: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							playerId: { type: 'string', description: 'Existing player id (see list_players).' },
+							role: { type: 'string', enum: [...TEAM_PLAYER_ROLES] },
+							startedOn: { type: 'string', description: 'YYYY-MM-DD' },
+							endedOn: { type: 'string', description: 'YYYY-MM-DD' },
+							note: { type: 'string' }
+						},
+						required: ['playerId', 'role'],
+						additionalProperties: false
+					}
+				},
+				slogans: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							slogan: { type: 'string' },
+							language: { type: 'string', description: 'Locale code, e.g. "en".' },
+							eventId: { type: 'string', description: 'Existing event id (optional).' }
+						},
+						required: ['slogan'],
+						additionalProperties: false
+					}
+				}
+			},
+			required: ['name'],
+			additionalProperties: false
+		},
+		handler: async (args, identity) => {
+			const name = requireString(args, 'name');
+			const region = optionalEnum(args.region, TEAM_REGIONS, 'region');
+			const players = Array.isArray(args.players)
+				? (args.players as Record<string, unknown>[]).map((p) => ({
+						playerId: requireString(p, 'playerId'),
+						role: optionalEnum(p.role, TEAM_PLAYER_ROLES, 'players.role') ?? 'active',
+						startedOn: typeof p.startedOn === 'string' ? p.startedOn : undefined,
+						endedOn: typeof p.endedOn === 'string' ? p.endedOn : undefined,
+						note: typeof p.note === 'string' ? p.note : undefined
+					}))
+				: undefined;
+			const slogans = Array.isArray(args.slogans)
+				? (args.slogans as Record<string, unknown>[]).map((s) => ({
+						slogan: requireString(s, 'slogan'),
+						language: typeof s.language === 'string' ? s.language : null,
+						eventId: typeof s.eventId === 'string' ? s.eventId : null
+					}))
+				: undefined;
+			const slug =
+				typeof args.slug === 'string' && args.slug.trim() ? args.slug.trim() : formatSlug(name);
+			const id = await createTeam(
+				{
+					name,
+					slug,
+					abbr: typeof args.abbr === 'string' ? args.abbr : undefined,
+					logo: typeof args.logo === 'string' ? args.logo : undefined,
+					region,
+					aliases: Array.isArray(args.aliases) ? (args.aliases as string[]) : undefined,
+					players,
+					slogans
+				},
+				identity.userId
 			);
 			return { id, slug, created: true };
 		}


### PR DESCRIPTION
Extends the MCP server beyond events so editors can **browse and create players and teams** from an AI client. Independent of #52/#53 (only touches the tool registry).

Designed from a research workflow that mapped both service layers and **adversarially verified** the specs against the real signatures.

## Tools added
| Tool | Scope |
|------|-------|
| `list_players` / `get_player` / `create_player` | read / read / **write** |
| `list_teams` / `get_team` / `create_team` | read / read / **write** |

Each wraps the existing data-layer service function, so edits get the same `edit_history` attribution as the admin UI.

## Safety
- **PII stripped from reads.** `getPlayer`/`getTeam` join the `user` table (email, username, player↔account linkage). A pure, **unit-tested** `project.ts` removes `user` from output — a security boundary, so it's tested in isolation.
- **Tool-level validation.** The service functions store `region`/`role`/game-account-region as plain text without validating, so `create_*` validate required fields (`requireString`) and enums (`optionalEnum`, also unit-tested). Game-account `server` is derived from `region`; `slug` defaults to `formatSlug(name)`.

## Deliberately deferred (documented)
- `update_player` / `update_team` — the service-layer update is a **destructive full-replacement** of nested collections (aliases/roster/accounts); a safe **merge-based** version (fetch current + overlay) is a follow-up.
- `delete_player` / `delete_team` — irreversible hard delete; deserves explicit opt-in.

## Verification
- `bun run check` → **0 errors**
- `bun test src/` → **103 pass** (new: `project` PII-strip, `optionalEnum`)
- new files eslint-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)