### PR TITLE
MCP OAuth (PR A): discovery metadata + token validation

### DIFF
--- a/drizzle/0003_lumpy_rachel_grey.sql
+++ b/drizzle/0003_lumpy_rachel_grey.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `oauth_client` (
+	`id` text PRIMARY KEY NOT NULL,
+	`client_name` text,
+	`redirect_uris` text NOT NULL,
+	`grant_types` text DEFAULT '["authorization_code"]' NOT NULL,
+	`response_types` text DEFAULT '["code"]' NOT NULL,
+	`token_endpoint_auth_method` text DEFAULT 'none' NOT NULL,
+	`scope` text,
+	`client_uri` text,
+	`logo_uri` text,
+	`software_id` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_oauth_client_created` ON `oauth_client` (`created_at`);--> statement-breakpoint
+CREATE TABLE `oauth_auth_code` (
+	`id` text PRIMARY KEY NOT NULL,
+	`code_hash` text NOT NULL,
+	`client_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`redirect_uri` text NOT NULL,
+	`code_challenge` text NOT NULL,
+	`code_challenge_method` text DEFAULT 'S256' NOT NULL,
+	`scope` text NOT NULL,
+	`resource` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`consumed_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`client_id`) REFERENCES `oauth_client`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauth_auth_code_code_hash_unique` ON `oauth_auth_code` (`code_hash`);--> statement-breakpoint
+CREATE INDEX `idx_oauth_code_client` ON `oauth_auth_code` (`client_id`);--> statement-breakpoint
+CREATE INDEX `idx_oauth_code_expires` ON `oauth_auth_code` (`expires_at`);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,4930 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "08931dfb-0be8-4522-83fc-eefed2b63e2e",
+  "prevId": "e0a2d697-5a73-467a-83db-27ee186ab233",
+  "tables": {
+    "role": {
+      "name": "role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_role": {
+      "name": "user_role",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_role_user": {
+          "name": "idx_user_role_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_role_role": {
+          "name": "idx_user_role_role",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_role_user_id_user_id_fk": {
+          "name": "user_role_user_id_user_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_role_id_fk": {
+          "name": "user_role_role_id_role_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_role_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_role_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_user": {
+          "name": "idx_session_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_token": {
+      "name": "password_reset_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_reset_token_token_unique": {
+          "name": "password_reset_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "password_reset_token_user_id_user_id_fk": {
+          "name": "password_reset_token_user_id_user_id_fk",
+          "tableFrom": "password_reset_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_token": {
+      "name": "mcp_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_token_token_hash_unique": {
+          "name": "mcp_token_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_token_user": {
+          "name": "idx_mcp_token_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_token": {
+          "name": "idx_mcp_audit_token",
+          "columns": [
+            "token_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_audit_created": {
+          "name": "idx_mcp_audit_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_token_id_mcp_token_id_fk": {
+          "name": "mcp_audit_log_token_id_mcp_token_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_audit_log_user_id_user_id_fk": {
+          "name": "mcp_audit_log_user_id_user_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_rate_limit": {
+      "name": "mcp_rate_limit",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_rate_limit_token_id_mcp_token_id_fk": {
+          "name": "mcp_rate_limit_token_id_mcp_token_id_fk",
+          "tableFrom": "mcp_rate_limit",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"authorization_code\"]'"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"code\"]'"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_client_created": {
+          "name": "idx_oauth_client_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_auth_code": {
+      "name": "oauth_auth_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'S256'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_auth_code_code_hash_unique": {
+          "name": "oauth_auth_code_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_code_client": {
+          "name": "idx_oauth_code_client",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_code_expires": {
+          "name": "idx_oauth_code_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_auth_code_client_id_oauth_client_id_fk": {
+          "name": "oauth_auth_code_client_id_oauth_client_id_fk",
+          "tableFrom": "oauth_auth_code",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_auth_code_user_id_user_id_fk": {
+          "name": "oauth_auth_code_user_id_user_id_fk",
+          "tableFrom": "oauth_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player": {
+      "name": "player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_slug_unique": {
+          "name": "player_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_player_user": {
+          "name": "idx_player_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_player_nationality": {
+          "name": "idx_player_nationality",
+          "columns": [
+            "nationality"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_user_id_user_id_fk": {
+          "name": "player_user_id_user_id_fk",
+          "tableFrom": "player",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_additional_nationality": {
+      "name": "player_additional_nationality",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pan_player": {
+          "name": "idx_pan_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pan_nationality": {
+          "name": "idx_pan_nationality",
+          "columns": [
+            "nationality"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_additional_nationality_player_id_player_id_fk": {
+          "name": "player_additional_nationality_player_id_player_id_fk",
+          "tableFrom": "player_additional_nationality",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_additional_nationality_player_id_nationality_pk": {
+          "columns": [
+            "player_id",
+            "nationality"
+          ],
+          "name": "player_additional_nationality_player_id_nationality_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_alias": {
+      "name": "player_alias",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pa_player": {
+          "name": "idx_pa_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_alias_player_id_player_id_fk": {
+          "name": "player_alias_player_id_player_id_fk",
+          "tableFrom": "player_alias",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_alias": {
+      "name": "team_alias",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ta_team": {
+          "name": "idx_ta_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_alias_team_id_alias_unique": {
+          "name": "team_alias_team_id_alias_unique",
+          "columns": [
+            "team_id",
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_alias_team_id_teams_id_fk": {
+          "name": "team_alias_team_id_teams_id_fk",
+          "tableFrom": "team_alias",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_player": {
+      "name": "team_player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_on": {
+          "name": "ended_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tp_team": {
+          "name": "idx_tp_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tp_player": {
+          "name": "idx_tp_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tp_role": {
+          "name": "idx_tp_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_player_team_id_teams_id_fk": {
+          "name": "team_player_team_id_teams_id_fk",
+          "tableFrom": "team_player",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_slogan": {
+      "name": "team_slogan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slogan": {
+          "name": "slogan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "team_slogan_team_slogan_dupe_guard": {
+          "name": "team_slogan_team_slogan_dupe_guard",
+          "columns": [
+            "team_id",
+            "event_id",
+            "slogan"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_slogan_team_id_teams_id_fk": {
+          "name": "team_slogan_team_id_teams_id_fk",
+          "tableFrom": "team_slogan",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "team_slogan_event_id_event_id_fk": {
+          "name": "team_slogan_event_id_event_id_fk",
+          "tableFrom": "team_slogan",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_account": {
+      "name": "game_account",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_name": {
+          "name": "current_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ga_player": {
+          "name": "idx_ga_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_account_player_id_player_id_fk": {
+          "name": "game_account_player_id_player_id_fk",
+          "tableFrom": "game_account",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_account_server_account_id_pk": {
+          "columns": [
+            "server",
+            "account_id"
+          ],
+          "name": "game_account_server_account_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "social_account": {
+      "name": "social_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overriding_url": {
+          "name": "overriding_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_psa_platform": {
+          "name": "idx_psa_platform",
+          "columns": [
+            "platform_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psa_player": {
+          "name": "idx_psa_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psa_account": {
+          "name": "idx_psa_account",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "social_account_platform_id_social_platform_id_fk": {
+          "name": "social_account_platform_id_social_platform_id_fk",
+          "tableFrom": "social_account",
+          "tableTo": "social_platform",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "social_account_player_id_player_id_fk": {
+          "name": "social_account_player_id_player_id_fk",
+          "tableFrom": "social_account",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "social_platform": {
+      "name": "social_platform",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_template": {
+          "name": "url_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event": {
+      "name": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "official": {
+          "name": "official",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_slug_unique": {
+          "name": "event_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_caster": {
+      "name": "event_caster",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_caster_event_id_event_id_fk": {
+          "name": "event_caster_event_id_event_id_fk",
+          "tableFrom": "event_caster",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_caster_player_id_player_id_fk": {
+          "name": "event_caster_player_id_player_id_fk",
+          "tableFrom": "event_caster",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_caster_event_id_player_id_pk": {
+          "columns": [
+            "event_id",
+            "player_id"
+          ],
+          "name": "event_caster_event_id_player_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_organizer": {
+      "name": "event_organizer",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_eo_event": {
+          "name": "idx_eo_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_organizer_event_id_event_id_fk": {
+          "name": "event_organizer_event_id_event_id_fk",
+          "tableFrom": "event_organizer",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_organizer_organizer_id_organizer_id_fk": {
+          "name": "event_organizer_organizer_id_organizer_id_fk",
+          "tableFrom": "event_organizer",
+          "tableTo": "organizer",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_organizer_event_id_organizer_id_pk": {
+          "columns": [
+            "event_id",
+            "organizer_id"
+          ],
+          "name": "event_organizer_event_id_organizer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_result": {
+      "name": "event_result",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank_to": {
+          "name": "rank_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_amount": {
+          "name": "prize_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_currency": {
+          "name": "prize_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_result_event_id_event_id_fk": {
+          "name": "event_result_event_id_event_id_fk",
+          "tableFrom": "event_result",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_result_team_id_teams_id_fk": {
+          "name": "event_result_team_id_teams_id_fk",
+          "tableFrom": "event_result",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_team": {
+      "name": "event_team",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_team_event_id_event_id_fk": {
+          "name": "event_team_event_id_event_id_fk",
+          "tableFrom": "event_team",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "event_team_team_id_teams_id_fk": {
+          "name": "event_team_team_id_teams_id_fk",
+          "tableFrom": "event_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_team_event_id_team_id_pk": {
+          "columns": [
+            "event_id",
+            "team_id"
+          ],
+          "name": "event_team_event_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_team_player": {
+      "name": "event_team_player",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_etp_event": {
+          "name": "idx_etp_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_team_player_event_id_event_id_fk": {
+          "name": "event_team_player_event_id_event_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_team_player_team_id_teams_id_fk": {
+          "name": "event_team_player_team_id_teams_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_team_player_player_id_player_id_fk": {
+          "name": "event_team_player_player_id_player_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_team_player_event_id_team_id_player_id_pk": {
+          "columns": [
+            "event_id",
+            "team_id",
+            "player_id"
+          ],
+          "name": "event_team_player_event_id_team_id_player_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_video": {
+      "name": "event_video",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_ev_event": {
+          "name": "idx_ev_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_video_event_id_event_id_fk": {
+          "name": "event_video_event_id_event_id_fk",
+          "tableFrom": "event_video",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_website": {
+      "name": "event_website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_website_event_id_event_id_fk": {
+          "name": "event_website_event_id_event_id_fk",
+          "tableFrom": "event_website",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizer": {
+      "name": "organizer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "organizer_slug_unique": {
+          "name": "organizer_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type": {
+          "name": "type",
+          "value": "\"organizer\".\"type\" IS NULL OR \"organizer\".\"type\" IN ('individual', 'organization', 'community', 'tournament_series', 'league')"
+        }
+      }
+    },
+    "organizer_user": {
+      "name": "organizer_user",
+      "columns": {
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizer_user_organizer_id_organizer_id_fk": {
+          "name": "organizer_user_organizer_id_organizer_id_fk",
+          "tableFrom": "organizer_user",
+          "tableTo": "organizer",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizer_user_user_id_user_id_fk": {
+          "name": "organizer_user_user_id_user_id_fk",
+          "tableFrom": "organizer_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organizer_user_organizer_id_user_id_pk": {
+          "columns": [
+            "organizer_id",
+            "user_id"
+          ],
+          "name": "organizer_user_organizer_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "character": {
+      "name": "character",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "map": {
+      "name": "map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_game_match": {
+          "name": "idx_game_match",
+          "columns": [
+            "match_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_match_id_match_id_fk": {
+          "name": "game_match_id_match_id_fk",
+          "tableFrom": "game",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_map_id_map_id_fk": {
+          "name": "game_map_id_map_id_fk",
+          "tableFrom": "game",
+          "tableTo": "map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_player_score": {
+      "name": "game_player_score",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_first_half": {
+          "name": "character_first_half",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character_second_half": {
+          "name": "character_second_half",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damage_score": {
+          "name": "damage_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knocks": {
+          "name": "knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_gps_game": {
+          "name": "idx_gps_game",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_team": {
+          "name": "idx_gps_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_account": {
+          "name": "idx_gps_account",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_char1": {
+          "name": "idx_gps_char1",
+          "columns": [
+            "character_first_half"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_char2": {
+          "name": "idx_gps_char2",
+          "columns": [
+            "character_second_half"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_player_score_game_id_game_id_fk": {
+          "name": "game_player_score_game_id_game_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_team_id_teams_id_fk": {
+          "name": "game_player_score_team_id_teams_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_character_first_half_character_id_fk": {
+          "name": "game_player_score_character_first_half_character_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_first_half"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_character_second_half_character_id_fk": {
+          "name": "game_player_score_character_second_half_character_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_second_half"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_team": {
+      "name": "game_team",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_gt_game": {
+          "name": "idx_gt_game",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gt_team": {
+          "name": "idx_gt_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_team_game_id_game_id_fk": {
+          "name": "game_team_game_id_game_id_fk",
+          "tableFrom": "game_team",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_team_team_id_teams_id_fk": {
+          "name": "game_team_team_id_teams_id_fk",
+          "tableFrom": "game_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_team_game_id_team_id_pk": {
+          "columns": [
+            "game_id",
+            "team_id"
+          ],
+          "name": "game_team_game_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "position": {
+          "name": "position",
+          "value": "\"game_team\".\"position\" IN (0, 1)"
+        }
+      }
+    },
+    "game_vod": {
+      "name": "game_vod",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "official": {
+          "name": "official",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available": {
+          "name": "available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_vod_game_id_game_id_fk": {
+          "name": "game_vod_game_id_game_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_vod_player_id_player_id_fk": {
+          "name": "game_vod_player_id_player_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_vod_team_id_teams_id_fk": {
+          "name": "game_vod_team_id_teams_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_vod_game_id_url_pk": {
+          "columns": [
+            "game_id",
+            "url"
+          ],
+          "name": "game_vod_game_id_url_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match": {
+      "name": "match",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_match_stage": {
+          "name": "idx_match_stage",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "format": {
+          "name": "format",
+          "value": "\"match\".\"format\" IN ('BO1', 'BO3', 'BO5')"
+        }
+      }
+    },
+    "match_map": {
+      "name": "match_map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_picker_position": {
+          "name": "map_picker_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side_picker_position": {
+          "name": "side_picker_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_map_match_id_match_id_fk": {
+          "name": "match_map_match_id_match_id_fk",
+          "tableFrom": "match_map",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_map_map_id_map_id_fk": {
+          "name": "match_map_map_id_map_id_fk",
+          "tableFrom": "match_map",
+          "tableTo": "map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match_team": {
+      "name": "match_team",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_team_match_id_match_id_fk": {
+          "name": "match_team_match_id_match_id_fk",
+          "tableFrom": "match_team",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_team_team_id_teams_id_fk": {
+          "name": "match_team_team_id_teams_id_fk",
+          "tableFrom": "match_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_team_match_id_team_id_pk": {
+          "columns": [
+            "match_id",
+            "team_id"
+          ],
+          "name": "match_team_match_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "position": {
+          "name": "position",
+          "value": "\"match_team\".\"position\" >= 0"
+        }
+      }
+    },
+    "event_stage": {
+      "name": "event_stage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_stage_event": {
+          "name": "idx_stage_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_stage_event_id_event_id_fk": {
+          "name": "event_stage_event_id_event_id_fk",
+          "tableFrom": "event_stage",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "stage": {
+          "name": "stage",
+          "value": "\"event_stage\".\"stage\" IN ('group', 'qualifier', 'showmatch', 'playoff')"
+        },
+        "format": {
+          "name": "format",
+          "value": "\"event_stage\".\"format\" IN ('single', 'double', 'swiss', 'round-robin')"
+        }
+      }
+    },
+    "stage_node": {
+      "name": "stage_node",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_node_stage_id_event_stage_id_fk": {
+          "name": "stage_node_stage_id_event_stage_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "event_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_match_id_match_id_fk": {
+          "name": "stage_node_match_id_match_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_round_id_stage_round_id_fk": {
+          "name": "stage_node_round_id_stage_round_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "stage_round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stage_node_dependency": {
+      "name": "stage_node_dependency",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependency_match_id": {
+          "name": "dependency_match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_node_dependency_node_id_stage_node_id_fk": {
+          "name": "stage_node_dependency_node_id_stage_node_id_fk",
+          "tableFrom": "stage_node_dependency",
+          "tableTo": "stage_node",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_dependency_dependency_match_id_match_id_fk": {
+          "name": "stage_node_dependency_dependency_match_id_match_id_fk",
+          "tableFrom": "stage_node_dependency",
+          "tableTo": "match",
+          "columnsFrom": [
+            "dependency_match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stage_round": {
+      "name": "stage_round",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bracket": {
+          "name": "bracket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_group": {
+          "name": "parallel_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_round_stage_id_event_stage_id_fk": {
+          "name": "stage_round_stage_id_event_stage_id_fk",
+          "tableFrom": "stage_round",
+          "tableTo": "event_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_mouse_settings": {
+      "name": "player_mouse_settings",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dpi": {
+          "name": "dpi",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitivity": {
+          "name": "sensitivity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "polling_rate_hz": {
+          "name": "polling_rate_hz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "windows_pointer_speed": {
+          "name": "windows_pointer_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mouse_smoothing": {
+          "name": "mouse_smoothing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mouse_model": {
+          "name": "mouse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vertical_sens_multiplier": {
+          "name": "vertical_sens_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shoulder_fire_sens_multiplier": {
+          "name": "shoulder_fire_sens_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_1_25x": {
+          "name": "ads_sens_1_25x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_1_5x": {
+          "name": "ads_sens_1_5x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_2_5x": {
+          "name": "ads_sens_2_5x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_4_0x": {
+          "name": "ads_sens_4_0x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_mouse_settings_player_id_player_id_fk": {
+          "name": "player_mouse_settings_player_id_player_id_fk",
+          "tableFrom": "player_mouse_settings",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_character_stats": {
+      "name": "player_character_stats",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "superstring_power": {
+          "name": "superstring_power",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_game_at": {
+          "name": "last_game_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_pcs_player": {
+          "name": "idx_pcs_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcs_character": {
+          "name": "idx_pcs_character",
+          "columns": [
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcs_player_total_games": {
+          "name": "idx_pcs_player_total_games",
+          "columns": [
+            "player_id",
+            "total_games",
+            "superstring_power",
+            "total_wins"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_character_stats_player_id_player_id_fk": {
+          "name": "player_character_stats_player_id_player_id_fk",
+          "tableFrom": "player_character_stats",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "player_character_stats_character_id_character_id_fk": {
+          "name": "player_character_stats_character_id_character_id_fk",
+          "tableFrom": "player_character_stats",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_character_stats_player_id_character_id_pk": {
+          "columns": [
+            "player_id",
+            "character_id"
+          ],
+          "name": "player_character_stats_player_id_character_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_character_stats_history": {
+      "name": "player_character_stats_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superstring_power": {
+          "name": "superstring_power",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_pcsh_player": {
+          "name": "idx_pcsh_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_character": {
+          "name": "idx_pcsh_character",
+          "columns": [
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_snapshot": {
+          "name": "idx_pcsh_snapshot",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_player_character": {
+          "name": "idx_pcsh_player_character",
+          "columns": [
+            "player_id",
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_player_snapshot": {
+          "name": "idx_pcsh_player_snapshot",
+          "columns": [
+            "player_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_character_stats_history_player_id_player_id_fk": {
+          "name": "player_character_stats_history_player_id_player_id_fk",
+          "tableFrom": "player_character_stats_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "player_character_stats_history_character_id_character_id_fk": {
+          "name": "player_character_stats_history_character_id_character_id_fk",
+          "tableFrom": "player_character_stats_history",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_stats": {
+      "name": "player_stats",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "player_rating": {
+          "name": "player_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "events_count": {
+          "name": "events_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_game_at": {
+          "name": "last_game_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_stats_player_id_player_id_fk": {
+          "name": "player_stats_player_id_player_id_fk",
+          "tableFrom": "player_stats",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_stats_history": {
+      "name": "player_stats_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_rating": {
+          "name": "player_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events_count": {
+          "name": "events_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_psh_player": {
+          "name": "idx_psh_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psh_snapshot": {
+          "name": "idx_psh_snapshot",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_psh_player_snapshot": {
+          "name": "idx_psh_player_snapshot",
+          "columns": [
+            "player_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_stats_history_player_id_player_id_fk": {
+          "name": "player_stats_history_player_id_player_id_fk",
+          "tableFrom": "player_stats_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "edit_history": {
+      "name": "edit_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_eh_table": {
+          "name": "idx_eh_table",
+          "columns": [
+            "table_name"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_record": {
+          "name": "idx_eh_record",
+          "columns": [
+            "record_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_edited_by": {
+          "name": "idx_eh_edited_by",
+          "columns": [
+            "edited_by"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_edited_at": {
+          "name": "idx_eh_edited_at",
+          "columns": [
+            "edited_at"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_table_record": {
+          "name": "idx_eh_table_record",
+          "columns": [
+            "table_name",
+            "record_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_table_edited_at": {
+          "name": "idx_eh_table_edited_at",
+          "columns": [
+            "table_name",
+            "edited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edit_history_edited_by_user_id_fk": {
+          "name": "edit_history_edited_by_user_id_fk",
+          "tableFrom": "edit_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_tag": {
+      "name": "community_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_ct_category": {
+          "name": "idx_ct_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_ct_category_value": {
+          "name": "idx_ct_category_value",
+          "columns": [
+            "category",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discord_server": {
+      "name": "discord_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "additional_link_text": {
+          "name": "additional_link_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_link_url": {
+          "name": "additional_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discord_server_tag": {
+      "name": "discord_server_tag",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_dst_server": {
+          "name": "idx_dst_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        },
+        "idx_dst_tag": {
+          "name": "idx_dst_tag",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "discord_server_tag_server_id_discord_server_id_fk": {
+          "name": "discord_server_tag_server_id_discord_server_id_fk",
+          "tableFrom": "discord_server_tag",
+          "tableTo": "discord_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discord_server_tag_tag_id_community_tag_id_fk": {
+          "name": "discord_server_tag_tag_id_community_tag_id_fk",
+          "tableFrom": "discord_server_tag",
+          "tableTo": "community_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "discord_server_tag_server_id_tag_id_pk": {
+          "columns": [
+            "server_id",
+            "tag_id"
+          ],
+          "name": "discord_server_tag_server_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deleted_record": {
+      "name": "deleted_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deleted_record_entity": {
+          "name": "idx_deleted_record_entity",
+          "columns": [
+            "entity"
+          ],
+          "isUnique": false
+        },
+        "idx_deleted_record_record": {
+          "name": "idx_deleted_record_record",
+          "columns": [
+            "record_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deleted_record_deleted_by_user_id_fk": {
+          "name": "deleted_record_deleted_by_user_id_fk",
+          "tableFrom": "deleted_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780206859689,
       "tag": "0002_awesome_carnage",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1780210892302,
+      "tag": "0003_lumpy_rachel_grey",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schemas/auth/index.ts
+++ b/src/lib/server/db/schemas/auth/index.ts
@@ -4,3 +4,5 @@ export * from './password-reset';
 export * from './mcp-token';
 export * from './mcp-audit-log';
 export * from './mcp-rate-limit';
+export * from './oauth-client';
+export * from './oauth-auth-code';

--- a/src/lib/server/db/schemas/auth/oauth-auth-code.ts
+++ b/src/lib/server/db/schemas/auth/oauth-auth-code.ts
@@ -1,0 +1,41 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { user } from './user';
+import { oauthClient } from './oauth-client';
+
+/**
+ * OAuth authorization codes (RFC 6749 + PKCE). Single-use, short-TTL, and bound
+ * to the client + exact redirect_uri + PKCE challenge + user + resource. Only
+ * the SHA-256 hash of the opaque code is stored; redemption is atomic
+ * (`consumedAt` set under a `WHERE consumedAt IS NULL` guard) so concurrent
+ * token requests can't double-spend a code.
+ */
+export const oauthAuthCode = sqliteTable(
+	'oauth_auth_code',
+	{
+		id: text('id').primaryKey(),
+		tokenHash: text('code_hash').notNull().unique(),
+		clientId: text('client_id')
+			.notNull()
+			.references(() => oauthClient.id, { onDelete: 'cascade' }),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id),
+		redirectUri: text('redirect_uri').notNull(),
+		codeChallenge: text('code_challenge').notNull(),
+		codeChallengeMethod: text('code_challenge_method').notNull().default('S256'),
+		scope: text('scope').notNull(), // granted scope (post-consent)
+		resource: text('resource').notNull(), // RFC 8707 — copied into the token aud
+		expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+		consumedAt: integer('consumed_at', { mode: 'timestamp' }),
+		createdAt: integer('created_at', { mode: 'timestamp' }).notNull()
+	},
+	(table) => {
+		return {
+			idx_client: index('idx_oauth_code_client').on(table.clientId),
+			idx_expires: index('idx_oauth_code_expires').on(table.expiresAt)
+		};
+	}
+);
+
+export type OAuthAuthCode = typeof oauthAuthCode.$inferSelect;
+export type NewOAuthAuthCode = typeof oauthAuthCode.$inferInsert;

--- a/src/lib/server/db/schemas/auth/oauth-client.ts
+++ b/src/lib/server/db/schemas/auth/oauth-client.ts
@@ -1,0 +1,30 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+
+/**
+ * Dynamically-registered (RFC 7591) OAuth clients for the MCP authorization
+ * flow. MCP clients are public (PKCE) — `token_endpoint_auth_method` is 'none'
+ * and there is no client secret. `redirect_uris` is a JSON array compared by
+ * EXACT string match at /authorize and /token.
+ */
+export const oauthClient = sqliteTable(
+	'oauth_client',
+	{
+		id: text('id').primaryKey(), // client_id (opaque random)
+		clientName: text('client_name'),
+		redirectUris: text('redirect_uris').notNull(), // JSON array of exact absolute URIs
+		grantTypes: text('grant_types').notNull().default('["authorization_code"]'),
+		responseTypes: text('response_types').notNull().default('["code"]'),
+		tokenEndpointAuthMethod: text('token_endpoint_auth_method').notNull().default('none'),
+		scope: text('scope'), // space-delimited allowed scopes
+		clientUri: text('client_uri'),
+		logoUri: text('logo_uri'),
+		softwareId: text('software_id'),
+		createdAt: integer('created_at', { mode: 'timestamp' }).notNull()
+	},
+	(table) => {
+		return { idx_created: index('idx_oauth_client_created').on(table.createdAt) };
+	}
+);
+
+export type OAuthClient = typeof oauthClient.$inferSelect;
+export type NewOAuthClient = typeof oauthClient.$inferInsert;

--- a/src/lib/server/oauth/config.ts
+++ b/src/lib/server/oauth/config.ts
@@ -1,0 +1,42 @@
+/**
+ * OAuth 2.1 configuration for the MCP authorization flow.
+ *
+ * Single source of truth so the metadata documents, the authorize/token
+ * endpoints, and token validation can never drift. Free of env/SvelteKit
+ * imports so it is safe to import from unit tests.
+ */
+
+// Mirrors SITE_CANONICAL_HOST in $lib/consts (inlined to keep this module
+// import-free for tests).
+export const OAUTH_ISSUER = 'https://lemontv.win';
+
+/**
+ * The canonical MCP resource identifier (RFC 8707). Access tokens are bound to
+ * this as their `aud`; the MCP route rejects any token whose audience differs —
+ * which is what keeps these tokens separate from the legacy /login/jwt SSO
+ * tokens (whose aud is the redirect origin) even though both use the same key.
+ */
+export const MCP_RESOURCE = `${OAUTH_ISSUER}/api/mcp`;
+
+export const OAUTH_SCOPES_SUPPORTED = ['mcp:read', 'mcp:write'] as const;
+export type OAuthScope = (typeof OAUTH_SCOPES_SUPPORTED)[number];
+
+export const PKCE_METHODS_SUPPORTED = ['S256'] as const;
+export const OAUTH_RESPONSE_TYPES_SUPPORTED = ['code'] as const;
+export const OAUTH_GRANT_TYPES_SUPPORTED = ['authorization_code'] as const;
+export const TOKEN_ENDPOINT_AUTH_METHODS = ['none'] as const; // public (PKCE) clients
+
+/** Authorization codes are single-use and very short-lived. */
+export const AUTH_CODE_TTL_MS = 60_000;
+/** Access tokens are short-lived; longevity comes from re-running the flow (refresh tokens: PR B). */
+export const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+
+/** Signing key id — reuses the existing ES256 key served at /.well-known/jwks.json. */
+export const JWT_KID = 'lemon-key';
+export const JWT_ALG = 'ES256';
+
+export const WELL_KNOWN_PROTECTED_RESOURCE = `${OAUTH_ISSUER}/.well-known/oauth-protected-resource`;
+export const JWKS_URI = `${OAUTH_ISSUER}/.well-known/jwks.json`;
+export const AUTHORIZATION_ENDPOINT = `${OAUTH_ISSUER}/oauth/authorize`;
+export const TOKEN_ENDPOINT = `${OAUTH_ISSUER}/oauth/token`;
+export const REGISTRATION_ENDPOINT = `${OAUTH_ISSUER}/oauth/register`;

--- a/src/lib/server/oauth/identity.ts
+++ b/src/lib/server/oauth/identity.ts
@@ -1,0 +1,42 @@
+/**
+ * Resolve an MCP identity from an OAuth access token.
+ *
+ * Verifies the JWT (aud-bound to the MCP resource), then loads the user and
+ * their CURRENT roles from the DB — roles are never trusted from the token, so
+ * de-authorizing an editor instantly defangs outstanding tokens (matching the
+ * PAT path). Write requires BOTH the `mcp:write` scope AND a live editor/admin role.
+ */
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import type { UserRole } from '$lib/data/user';
+import type { McpIdentity } from '$lib/server/mcp/server';
+import { MCP_WRITE_ROLES } from '$lib/server/security/mcp-token';
+import { verifyAccessToken } from './token';
+
+export async function identityFromOAuthToken(jwt: string): Promise<McpIdentity | null> {
+	const claims = await verifyAccessToken(jwt);
+	if (!claims) return null;
+
+	const [owner] = await db
+		.select({ id: table.user.id, username: table.user.username })
+		.from(table.user)
+		.where(eq(table.user.id, claims.sub));
+	if (!owner) return null;
+
+	const roleRows = await db
+		.select({ roleId: table.userRole.roleId })
+		.from(table.userRole)
+		.where(eq(table.userRole.userId, owner.id));
+	const roles = roleRows.map((r) => r.roleId as UserRole);
+
+	const hasWriteScope = claims.scope.split(' ').includes('mcp:write');
+	const canWrite = hasWriteScope && MCP_WRITE_ROLES.some((role) => roles.includes(role));
+
+	return {
+		tokenId: `oauth:${claims.jti}`,
+		userId: owner.id,
+		username: owner.username,
+		canWrite
+	};
+}

--- a/src/lib/server/oauth/pkce.test.ts
+++ b/src/lib/server/oauth/pkce.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import {
+	computeS256Challenge,
+	verifyPkceS256,
+	redirectUriMatches,
+	isAcceptableRedirectUri
+} from './pkce';
+
+// RFC 7636 Appendix B test vector.
+const RFC_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const RFC_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+describe('PKCE S256', () => {
+	it('matches the RFC 7636 test vector', () => {
+		expect(computeS256Challenge(RFC_VERIFIER)).toBe(RFC_CHALLENGE);
+		expect(verifyPkceS256(RFC_VERIFIER, RFC_CHALLENGE)).toBe(true);
+	});
+
+	it('rejects a wrong verifier', () => {
+		expect(verifyPkceS256('x'.repeat(43), RFC_CHALLENGE)).toBe(false);
+	});
+
+	it('rejects verifiers outside the 43–128 length bound', () => {
+		expect(verifyPkceS256('short', computeS256Challenge('short'))).toBe(false);
+		expect(verifyPkceS256('x'.repeat(129), computeS256Challenge('x'.repeat(129)))).toBe(false);
+	});
+
+	it('rejects empty inputs', () => {
+		expect(verifyPkceS256('', RFC_CHALLENGE)).toBe(false);
+		expect(verifyPkceS256(RFC_VERIFIER, '')).toBe(false);
+	});
+});
+
+describe('redirectUriMatches', () => {
+	const registered = ['https://claude.ai/api/mcp/auth_callback', 'http://localhost:33418/callback'];
+
+	it('matches an exact registered URI', () => {
+		expect(redirectUriMatches(registered, 'https://claude.ai/api/mcp/auth_callback')).toBe(true);
+	});
+
+	it('rejects near-misses (trailing slash, extra query, different path)', () => {
+		expect(redirectUriMatches(registered, 'https://claude.ai/api/mcp/auth_callback/')).toBe(false);
+		expect(redirectUriMatches(registered, 'https://claude.ai/api/mcp/auth_callback?x=1')).toBe(
+			false
+		);
+		expect(redirectUriMatches(registered, 'https://claude.ai/evil')).toBe(false);
+		expect(redirectUriMatches(registered, 'https://evil.com/api/mcp/auth_callback')).toBe(false);
+		expect(redirectUriMatches(registered, '')).toBe(false);
+	});
+});
+
+describe('isAcceptableRedirectUri', () => {
+	it('accepts absolute https and loopback http', () => {
+		expect(isAcceptableRedirectUri('https://claude.ai/callback')).toBe(true);
+		expect(isAcceptableRedirectUri('http://localhost:1234/cb')).toBe(true);
+		expect(isAcceptableRedirectUri('http://127.0.0.1:1234/cb')).toBe(true);
+	});
+
+	it('rejects non-loopback http, fragments, and garbage', () => {
+		expect(isAcceptableRedirectUri('http://evil.com/cb')).toBe(false);
+		expect(isAcceptableRedirectUri('https://ok.com/cb#frag')).toBe(false);
+		expect(isAcceptableRedirectUri('not-a-url')).toBe(false);
+		expect(isAcceptableRedirectUri('ftp://x/y')).toBe(false);
+	});
+});

--- a/src/lib/server/oauth/pkce.ts
+++ b/src/lib/server/oauth/pkce.ts
@@ -1,0 +1,57 @@
+/**
+ * PKCE (RFC 7636, S256 only) and redirect-URI matching — pure, unit-tested.
+ *
+ * The security of the public-client (no client secret) OAuth flow rests on
+ * these: PKCE proves the token requester is the same party that started the
+ * authorization, and exact redirect-URI matching prevents open-redirect / code
+ * theft.
+ */
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/** S256 code challenge = base64url(SHA-256(code_verifier)), no padding. */
+export function computeS256Challenge(codeVerifier: string): string {
+	return createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+	const ab = Buffer.from(a);
+	const bb = Buffer.from(b);
+	if (ab.length !== bb.length) return false;
+	return timingSafeEqual(ab, bb);
+}
+
+/** Verify a PKCE S256 code_verifier against the stored code_challenge. */
+export function verifyPkceS256(codeVerifier: string, codeChallenge: string): boolean {
+	if (!codeVerifier || !codeChallenge) return false;
+	// RFC 7636: verifier is 43–128 chars of the unreserved set.
+	if (codeVerifier.length < 43 || codeVerifier.length > 128) return false;
+	return constantTimeEquals(computeS256Challenge(codeVerifier), codeChallenge);
+}
+
+/**
+ * Exact redirect-URI match against the client's registered URIs. No
+ * normalization, no prefix/substring, no wildcards — byte-for-byte.
+ */
+export function redirectUriMatches(registeredUris: readonly string[], presented: string): boolean {
+	if (!presented) return false;
+	return registeredUris.some((uri) => constantTimeEquals(uri, presented));
+}
+
+/**
+ * A redirect URI acceptable for registration: absolute https, OR http only for
+ * loopback (native clients). No fragment.
+ */
+export function isAcceptableRedirectUri(value: string): boolean {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return false;
+	}
+	if (url.hash) return false;
+	if (url.protocol === 'https:') return true;
+	if (url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1')) {
+		return true;
+	}
+	return false;
+}

--- a/src/lib/server/oauth/token-core.test.ts
+++ b/src/lib/server/oauth/token-core.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test';
+import { SignJWT, generateKeyPair, generateSecret } from 'jose';
+import { signAccessToken, verifyAccessTokenWith } from './token-core';
+import { MCP_RESOURCE, OAUTH_ISSUER } from './config';
+
+const { privateKey, publicKey } = await generateKeyPair('ES256');
+
+describe('access token sign/verify', () => {
+	it('round-trips a valid token with the resource audience', async () => {
+		const jwt = await signAccessToken(privateKey, {
+			sub: 'u1',
+			scope: 'mcp:read mcp:write',
+			clientId: 'c1'
+		});
+		const claims = await verifyAccessTokenWith(publicKey, jwt);
+		expect(claims.sub).toBe('u1');
+		expect(claims.scope).toBe('mcp:read mcp:write');
+		expect(claims.clientId).toBe('c1');
+		expect(claims.jti.length).toBeGreaterThan(0);
+	});
+
+	it('REJECTS a token whose audience is not the MCP resource (the SSO-token defense)', async () => {
+		// Mimics the legacy /login/jwt token: same key, but aud = an app origin.
+		const ssoLike = await new SignJWT({ scope: 'mcp:write' })
+			.setProtectedHeader({ alg: 'ES256', kid: 'lemon-key' })
+			.setIssuer(OAUTH_ISSUER)
+			.setAudience('https://lemontv.win') // NOT the MCP resource
+			.setSubject('u1')
+			.setIssuedAt()
+			.setExpirationTime('1h')
+			.sign(privateKey);
+		await expect(verifyAccessTokenWith(publicKey, ssoLike)).rejects.toThrow();
+	});
+
+	it('REJECTS a wrong issuer', async () => {
+		const badIss = await new SignJWT({ scope: 'mcp:read' })
+			.setProtectedHeader({ alg: 'ES256' })
+			.setIssuer('https://evil.example')
+			.setAudience(MCP_RESOURCE)
+			.setSubject('u1')
+			.setIssuedAt()
+			.setExpirationTime('1h')
+			.sign(privateKey);
+		await expect(verifyAccessTokenWith(publicKey, badIss)).rejects.toThrow();
+	});
+
+	it('REJECTS an HS256 token (algorithm-confusion defense)', async () => {
+		const secret = await generateSecret('HS256');
+		const hs = await new SignJWT({ scope: 'mcp:write' })
+			.setProtectedHeader({ alg: 'HS256' })
+			.setIssuer(OAUTH_ISSUER)
+			.setAudience(MCP_RESOURCE)
+			.setSubject('u1')
+			.setIssuedAt()
+			.setExpirationTime('1h')
+			.sign(secret);
+		await expect(verifyAccessTokenWith(publicKey, hs)).rejects.toThrow();
+	});
+
+	it('REJECTS an expired token', async () => {
+		const expired = await new SignJWT({ scope: 'mcp:read' })
+			.setProtectedHeader({ alg: 'ES256' })
+			.setIssuer(OAUTH_ISSUER)
+			.setAudience(MCP_RESOURCE)
+			.setSubject('u1')
+			.setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+			.setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+			.sign(privateKey);
+		await expect(verifyAccessTokenWith(publicKey, expired)).rejects.toThrow();
+	});
+});

--- a/src/lib/server/oauth/token-core.ts
+++ b/src/lib/server/oauth/token-core.ts
@@ -1,0 +1,60 @@
+/**
+ * MCP access-token signing/verification — pure core.
+ *
+ * Takes keys as parameters (no env/SvelteKit imports) so it is unit-testable
+ * with a generated key pair. Env-bound wrappers live in `./token.ts`.
+ *
+ * The security-critical invariant: every token's `aud` is the MCP resource, and
+ * verification PINS the algorithm to ES256 and REQUIRES issuer + audience ===
+ * the MCP resource. This is what keeps these tokens from being confused with the
+ * legacy /login/jwt SSO tokens (different `aud`) even though both use one key.
+ */
+import { SignJWT, jwtVerify } from 'jose';
+import { randomUUID } from 'node:crypto';
+import { OAUTH_ISSUER, MCP_RESOURCE, JWT_ALG, JWT_KID, ACCESS_TOKEN_TTL_SECONDS } from './config';
+
+type SignKey = Parameters<InstanceType<typeof SignJWT>['sign']>[0];
+type VerifyKey = CryptoKey | Uint8Array;
+
+export interface AccessTokenClaims {
+	sub: string;
+	scope: string;
+	clientId: string;
+	jti: string;
+}
+
+export async function signAccessToken(
+	privateKey: SignKey,
+	params: { sub: string; scope: string; clientId: string; jti?: string; ttlSeconds?: number }
+): Promise<string> {
+	const jti = params.jti ?? randomUUID();
+	const ttl = params.ttlSeconds ?? ACCESS_TOKEN_TTL_SECONDS;
+	return new SignJWT({ scope: params.scope, azp: params.clientId, client_id: params.clientId })
+		.setProtectedHeader({ alg: JWT_ALG, kid: JWT_KID })
+		.setIssuer(OAUTH_ISSUER)
+		.setAudience(MCP_RESOURCE)
+		.setSubject(params.sub)
+		.setJti(jti)
+		.setIssuedAt()
+		.setExpirationTime(`${ttl}s`)
+		.sign(privateKey);
+}
+
+/** Verify a token. Throws (jose) on bad signature, wrong alg/issuer/audience, or expiry. */
+export async function verifyAccessTokenWith(
+	publicKey: VerifyKey,
+	jwt: string
+): Promise<AccessTokenClaims> {
+	const { payload } = await jwtVerify(jwt, publicKey, {
+		algorithms: [JWT_ALG], // pin ES256 — reject none/HS256/RS256 (alg-confusion defense)
+		issuer: OAUTH_ISSUER,
+		audience: MCP_RESOURCE, // resource binding — throws on mismatch
+		requiredClaims: ['sub', 'scope', 'exp', 'iat']
+	});
+	return {
+		sub: payload.sub as string,
+		scope: typeof payload.scope === 'string' ? payload.scope : '',
+		clientId: (payload.azp ?? payload.client_id ?? '') as string,
+		jti: (payload.jti ?? '') as string
+	};
+}

--- a/src/lib/server/oauth/token.ts
+++ b/src/lib/server/oauth/token.ts
@@ -1,0 +1,46 @@
+/**
+ * Env-bound wrappers around the pure token core — load the existing ES256 key
+ * material (the same key served at /.well-known/jwks.json) and mint/verify MCP
+ * access tokens.
+ */
+import { importJWK } from 'jose';
+import { Buffer } from 'node:buffer';
+import { LEMON_PRIVATE_JWK_BASE64, LEMON_PUBLIC_JWK_BASE64 } from '$env/static/private';
+import { JWT_ALG } from './config';
+import { signAccessToken, verifyAccessTokenWith, type AccessTokenClaims } from './token-core';
+
+type ImportedKey = Awaited<ReturnType<typeof importJWK>>;
+
+function decodeJwk(base64: string): Record<string, unknown> {
+	return JSON.parse(Buffer.from(base64, 'base64url').toString('utf8'));
+}
+
+let privateKey: Promise<ImportedKey> | null = null;
+let publicKey: Promise<ImportedKey> | null = null;
+
+function getPrivateKey(): Promise<ImportedKey> {
+	if (!privateKey) privateKey = importJWK(decodeJwk(LEMON_PRIVATE_JWK_BASE64), JWT_ALG);
+	return privateKey;
+}
+function getPublicKey(): Promise<ImportedKey> {
+	if (!publicKey) publicKey = importJWK(decodeJwk(LEMON_PUBLIC_JWK_BASE64), JWT_ALG);
+	return publicKey;
+}
+
+export async function mintAccessToken(params: {
+	sub: string;
+	scope: string;
+	clientId: string;
+	ttlSeconds?: number;
+}): Promise<string> {
+	return signAccessToken(await getPrivateKey(), params);
+}
+
+/** Verify an MCP access token. Returns null on any failure (route maps null → 401). */
+export async function verifyAccessToken(jwt: string): Promise<AccessTokenClaims | null> {
+	try {
+		return await verifyAccessTokenWith(await getPublicKey(), jwt);
+	} catch {
+		return null;
+	}
+}

--- a/src/routes/.well-known/oauth-authorization-server/+server.ts
+++ b/src/routes/.well-known/oauth-authorization-server/+server.ts
@@ -1,0 +1,37 @@
+/**
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414). Public — `/.well-known/`
+ * is whitelisted in hooks. MCP clients discover the authorize/token/registration
+ * endpoints here.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+	OAUTH_ISSUER,
+	AUTHORIZATION_ENDPOINT,
+	TOKEN_ENDPOINT,
+	REGISTRATION_ENDPOINT,
+	JWKS_URI,
+	OAUTH_SCOPES_SUPPORTED,
+	OAUTH_RESPONSE_TYPES_SUPPORTED,
+	OAUTH_GRANT_TYPES_SUPPORTED,
+	PKCE_METHODS_SUPPORTED,
+	TOKEN_ENDPOINT_AUTH_METHODS
+} from '$lib/server/oauth/config';
+
+export const GET: RequestHandler = () => {
+	return json(
+		{
+			issuer: OAUTH_ISSUER,
+			authorization_endpoint: AUTHORIZATION_ENDPOINT,
+			token_endpoint: TOKEN_ENDPOINT,
+			registration_endpoint: REGISTRATION_ENDPOINT,
+			jwks_uri: JWKS_URI,
+			scopes_supported: [...OAUTH_SCOPES_SUPPORTED],
+			response_types_supported: [...OAUTH_RESPONSE_TYPES_SUPPORTED],
+			grant_types_supported: [...OAUTH_GRANT_TYPES_SUPPORTED],
+			code_challenge_methods_supported: [...PKCE_METHODS_SUPPORTED],
+			token_endpoint_auth_methods_supported: [...TOKEN_ENDPOINT_AUTH_METHODS]
+		},
+		{ headers: { 'Cache-Control': 'public, max-age=3600' } }
+	);
+};

--- a/src/routes/.well-known/oauth-protected-resource/+server.ts
+++ b/src/routes/.well-known/oauth-protected-resource/+server.ts
@@ -1,0 +1,20 @@
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728). Advertises that the MCP
+ * resource is protected and which authorization server issues tokens for it.
+ * The MCP route's 401 `WWW-Authenticate` points here.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { MCP_RESOURCE, OAUTH_ISSUER, OAUTH_SCOPES_SUPPORTED } from '$lib/server/oauth/config';
+
+export const GET: RequestHandler = () => {
+	return json(
+		{
+			resource: MCP_RESOURCE,
+			authorization_servers: [OAUTH_ISSUER],
+			scopes_supported: [...OAUTH_SCOPES_SUPPORTED],
+			bearer_methods_supported: ['header']
+		},
+		{ headers: { 'Cache-Control': 'public, max-age=3600' } }
+	);
+};

--- a/src/routes/api/mcp/+server.ts
+++ b/src/routes/api/mcp/+server.ts
@@ -1,16 +1,24 @@
 /**
  * Authorized MCP server — HTTP transport.
  *
- * Speaks MCP over JSON-RPC via HTTP POST, authenticated by a LemonTV Personal
- * Access Token (`Authorization: Bearer lemon_pat_…`). NOT mounted under
- * /api/public/ (which is pre-auth) — this route authenticates every request
- * itself and resolves the caller's write capability before dispatch.
+ * Speaks MCP over JSON-RPC via HTTP POST. Two credential types are accepted:
+ *  - a LemonTV Personal Access Token (`Authorization: Bearer lemon_pat_…`), or
+ *  - an OAuth 2.1 access token (a JWT obtained via the browser login flow).
+ * NOT mounted under /api/public/ (which is pre-auth) — this route authenticates
+ * every request itself and resolves the caller's write capability before dispatch.
+ * On 401 it advertises the OAuth resource metadata so MCP clients can discover
+ * the login flow.
  */
 import { json, error as kitError } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { validateMcpToken } from '$lib/server/security/mcp-token-store';
+import { MCP_TOKEN_PREFIX } from '$lib/server/security/mcp-token';
 import { handleMcpMessage, type McpIdentity, type McpHooks } from '$lib/server/mcp/server';
 import { consumeRateLimit, logMcpAudit } from '$lib/server/mcp/hooks';
+import { identityFromOAuthToken } from '$lib/server/oauth/identity';
+import { WELL_KNOWN_PROTECTED_RESOURCE } from '$lib/server/oauth/config';
+
+const WWW_AUTHENTICATE = `Bearer resource_metadata="${WELL_KNOWN_PROTECTED_RESOURCE}"`;
 
 function bearerToken(request: Request): string | null {
 	const header = request.headers.get('authorization');
@@ -19,40 +27,44 @@ function bearerToken(request: Request): string | null {
 	return match ? match[1].trim() : null;
 }
 
+function unauthorized(message: string) {
+	return json(
+		{ jsonrpc: '2.0', id: null, error: { code: -32001, message } },
+		{ status: 401, headers: { 'WWW-Authenticate': WWW_AUTHENTICATE } }
+	);
+}
+
 export const POST: RequestHandler = async ({ request }) => {
 	const token = bearerToken(request);
-	if (!token) {
-		return json(
-			{ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Missing bearer token' } },
-			{ status: 401, headers: { 'WWW-Authenticate': 'Bearer' } }
-		);
+	if (!token) return unauthorized('Missing bearer token');
+
+	let identity: McpIdentity;
+	let hooks: McpHooks | undefined;
+
+	if (token.startsWith(MCP_TOKEN_PREFIX)) {
+		// Personal Access Token — audited + rate-limited by token id.
+		const validation = await validateMcpToken(token);
+		if (validation.status !== 'valid') return unauthorized(`Unauthorized (${validation.reason})`);
+		identity = {
+			tokenId: validation.token.id,
+			userId: validation.user.id,
+			username: validation.user.username,
+			canWrite: validation.canWrite
+		};
+		const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
+		hooks = {
+			rateLimit: (id) => consumeRateLimit(id.tokenId),
+			audit: (entry) =>
+				logMcpAudit({ ...entry, tokenId: identity.tokenId, userId: identity.userId, ip })
+		};
+	} else {
+		// OAuth 2.1 access token (JWT). Audit/rate-limit for OAuth lands when the
+		// PAT-keyed audit/rate-limit tables are generalized (follow-up).
+		const oauthIdentity = await identityFromOAuthToken(token);
+		if (!oauthIdentity) return unauthorized('Unauthorized (invalid token)');
+		identity = oauthIdentity;
+		hooks = undefined;
 	}
-
-	const validation = await validateMcpToken(token);
-	if (validation.status !== 'valid') {
-		return json(
-			{
-				jsonrpc: '2.0',
-				id: null,
-				error: { code: -32001, message: `Unauthorized (${validation.reason})` }
-			},
-			{ status: 401 }
-		);
-	}
-
-	const identity: McpIdentity = {
-		tokenId: validation.token.id,
-		userId: validation.user.id,
-		username: validation.user.username,
-		canWrite: validation.canWrite
-	};
-
-	const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
-	const hooks: McpHooks = {
-		rateLimit: (id) => consumeRateLimit(id.tokenId),
-		audit: (entry) =>
-			logMcpAudit({ ...entry, tokenId: identity.tokenId, userId: identity.userId, ip })
-	};
 
 	let body: unknown;
 	try {


### PR DESCRIPTION
First half of MCP OAuth login — so an MCP client (Claude Code / Desktop) can connect and **log into LemonTV in the browser** instead of pasting a PAT. This PR is the **resource-server + crypto** side; **PR B** adds the authorization server (`/oauth/register`, `/oauth/authorize` + consent, `/oauth/token`) that issues the tokens.

Built from a spec-grounded, **adversarially security-reviewed** plan (PKCE, redirect-URI matching, code replay, token audience all addressed).

## What's here
- **Discovery metadata** (public): `/.well-known/oauth-authorization-server` (RFC 8414) + `/.well-known/oauth-protected-resource` (RFC 9728). The MCP route's `401` now returns `WWW-Authenticate: Bearer resource_metadata="…"` so clients auto-discover the flow.
- **Token crypto** reusing the existing ES256 key + JWKS — no new secrets. `token-core.ts` is pure + unit-tested.
- **The security linchpin — audience binding:** access tokens have `aud = https://lemontv.win/api/mcp`; verification **pins ES256** and requires `iss` + `aud`. The legacy `/login/jwt` SSO token (`aud` = app origin) is therefore **rejected** at `/api/mcp` even though it's signed with the same key. Tested.
- **MCP route** accepts OAuth JWTs alongside PATs; `identity.ts` re-resolves **live roles** (write = `mcp:write` scope **and** a current editor/admin role), never trusting roles from the token.
- **Schemas** `oauth_client` (DCR) + `oauth_auth_code` (single-use, PKCE-bound, short-TTL) + migration `0003` (2 tables, **0 rebuilds**).

## Tested
`bun run check` → 0 errors; `bun test src/` → **137 pass** (13 new): PKCE S256 (RFC 7636 vector), exact redirect-URI match, and token aud-binding / alg-confusion / issuer / expiry rejection.

## Notes
- Not usable end-to-end until **PR B** issues tokens.
- OAuth audit/rate-limit deferred until the PAT-keyed audit/rate-limit tables are generalized (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)