### PR TITLE
MCP OAuth (PR B): authorization server (register + authorize + token + refresh)

### DIFF
--- a/drizzle/0004_married_jasper_sitwell.sql
+++ b/drizzle/0004_married_jasper_sitwell.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `oauth_refresh_token` (
+	`id` text PRIMARY KEY NOT NULL,
+	`token_hash` text NOT NULL,
+	`client_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`scope` text NOT NULL,
+	`resource` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`consumed_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`client_id`) REFERENCES `oauth_client`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauth_refresh_token_token_hash_unique` ON `oauth_refresh_token` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `idx_oauth_refresh_client` ON `oauth_refresh_token` (`client_id`);--> statement-breakpoint
+CREATE INDEX `idx_oauth_refresh_user` ON `oauth_refresh_token` (`user_id`);--> statement-breakpoint
+CREATE INDEX `idx_oauth_refresh_expires` ON `oauth_refresh_token` (`expires_at`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,5059 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8f48170f-ee60-4241-9693-acadb413b02b",
+  "prevId": "08931dfb-0be8-4522-83fc-eefed2b63e2e",
+  "tables": {
+    "role": {
+      "name": "role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_role": {
+      "name": "user_role",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_role_user": {
+          "name": "idx_user_role_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_role_role": {
+          "name": "idx_user_role_role",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_role_user_id_user_id_fk": {
+          "name": "user_role_user_id_user_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_role_id_fk": {
+          "name": "user_role_role_id_role_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_role_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_role_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_user": {
+          "name": "idx_session_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_token": {
+      "name": "password_reset_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "password_reset_token_token_unique": {
+          "name": "password_reset_token_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "password_reset_token_user_id_user_id_fk": {
+          "name": "password_reset_token_user_id_user_id_fk",
+          "tableFrom": "password_reset_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_token": {
+      "name": "mcp_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_token_token_hash_unique": {
+          "name": "mcp_token_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_token_user": {
+          "name": "idx_mcp_token_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_user_id_user_id_fk": {
+          "name": "mcp_token_user_id_user_id_fk",
+          "tableFrom": "mcp_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_token": {
+          "name": "idx_mcp_audit_token",
+          "columns": [
+            "token_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_audit_created": {
+          "name": "idx_mcp_audit_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_token_id_mcp_token_id_fk": {
+          "name": "mcp_audit_log_token_id_mcp_token_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_audit_log_user_id_user_id_fk": {
+          "name": "mcp_audit_log_user_id_user_id_fk",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_rate_limit": {
+      "name": "mcp_rate_limit",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_rate_limit_token_id_mcp_token_id_fk": {
+          "name": "mcp_rate_limit_token_id_mcp_token_id_fk",
+          "tableFrom": "mcp_rate_limit",
+          "tableTo": "mcp_token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"authorization_code\"]'"
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"code\"]'"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_uri": {
+          "name": "client_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_uri": {
+          "name": "logo_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_client_created": {
+          "name": "idx_oauth_client_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_auth_code": {
+      "name": "oauth_auth_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'S256'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_auth_code_code_hash_unique": {
+          "name": "oauth_auth_code_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_code_client": {
+          "name": "idx_oauth_code_client",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_code_expires": {
+          "name": "idx_oauth_code_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_auth_code_client_id_oauth_client_id_fk": {
+          "name": "oauth_auth_code_client_id_oauth_client_id_fk",
+          "tableFrom": "oauth_auth_code",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_auth_code_user_id_user_id_fk": {
+          "name": "oauth_auth_code_user_id_user_id_fk",
+          "tableFrom": "oauth_auth_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_token_hash_unique": {
+          "name": "oauth_refresh_token_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_oauth_refresh_client": {
+          "name": "idx_oauth_refresh_client",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_refresh_user": {
+          "name": "idx_oauth_refresh_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_oauth_refresh_expires": {
+          "name": "idx_oauth_refresh_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player": {
+      "name": "player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_slug_unique": {
+          "name": "player_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_player_user": {
+          "name": "idx_player_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_player_nationality": {
+          "name": "idx_player_nationality",
+          "columns": [
+            "nationality"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_user_id_user_id_fk": {
+          "name": "player_user_id_user_id_fk",
+          "tableFrom": "player",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_additional_nationality": {
+      "name": "player_additional_nationality",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pan_player": {
+          "name": "idx_pan_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pan_nationality": {
+          "name": "idx_pan_nationality",
+          "columns": [
+            "nationality"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_additional_nationality_player_id_player_id_fk": {
+          "name": "player_additional_nationality_player_id_player_id_fk",
+          "tableFrom": "player_additional_nationality",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_additional_nationality_player_id_nationality_pk": {
+          "columns": [
+            "player_id",
+            "nationality"
+          ],
+          "name": "player_additional_nationality_player_id_nationality_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_alias": {
+      "name": "player_alias",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pa_player": {
+          "name": "idx_pa_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_alias_player_id_player_id_fk": {
+          "name": "player_alias_player_id_player_id_fk",
+          "tableFrom": "player_alias",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_alias": {
+      "name": "team_alias",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ta_team": {
+          "name": "idx_ta_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_alias_team_id_alias_unique": {
+          "name": "team_alias_team_id_alias_unique",
+          "columns": [
+            "team_id",
+            "alias"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_alias_team_id_teams_id_fk": {
+          "name": "team_alias_team_id_teams_id_fk",
+          "tableFrom": "team_alias",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_player": {
+      "name": "team_player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_on": {
+          "name": "ended_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tp_team": {
+          "name": "idx_tp_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tp_player": {
+          "name": "idx_tp_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tp_role": {
+          "name": "idx_tp_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_player_team_id_teams_id_fk": {
+          "name": "team_player_team_id_teams_id_fk",
+          "tableFrom": "team_player",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_slogan": {
+      "name": "team_slogan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slogan": {
+          "name": "slogan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "team_slogan_team_slogan_dupe_guard": {
+          "name": "team_slogan_team_slogan_dupe_guard",
+          "columns": [
+            "team_id",
+            "event_id",
+            "slogan"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_slogan_team_id_teams_id_fk": {
+          "name": "team_slogan_team_id_teams_id_fk",
+          "tableFrom": "team_slogan",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "team_slogan_event_id_event_id_fk": {
+          "name": "team_slogan_event_id_event_id_fk",
+          "tableFrom": "team_slogan",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_account": {
+      "name": "game_account",
+      "columns": {
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_name": {
+          "name": "current_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ga_player": {
+          "name": "idx_ga_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_account_player_id_player_id_fk": {
+          "name": "game_account_player_id_player_id_fk",
+          "tableFrom": "game_account",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_account_server_account_id_pk": {
+          "columns": [
+            "server",
+            "account_id"
+          ],
+          "name": "game_account_server_account_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "social_account": {
+      "name": "social_account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "overriding_url": {
+          "name": "overriding_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_psa_platform": {
+          "name": "idx_psa_platform",
+          "columns": [
+            "platform_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psa_player": {
+          "name": "idx_psa_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psa_account": {
+          "name": "idx_psa_account",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "social_account_platform_id_social_platform_id_fk": {
+          "name": "social_account_platform_id_social_platform_id_fk",
+          "tableFrom": "social_account",
+          "tableTo": "social_platform",
+          "columnsFrom": [
+            "platform_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "social_account_player_id_player_id_fk": {
+          "name": "social_account_player_id_player_id_fk",
+          "tableFrom": "social_account",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "social_platform": {
+      "name": "social_platform",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_template": {
+          "name": "url_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event": {
+      "name": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "official": {
+          "name": "official",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server": {
+          "name": "server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_slug_unique": {
+          "name": "event_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_caster": {
+      "name": "event_caster",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_caster_event_id_event_id_fk": {
+          "name": "event_caster_event_id_event_id_fk",
+          "tableFrom": "event_caster",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_caster_player_id_player_id_fk": {
+          "name": "event_caster_player_id_player_id_fk",
+          "tableFrom": "event_caster",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_caster_event_id_player_id_pk": {
+          "columns": [
+            "event_id",
+            "player_id"
+          ],
+          "name": "event_caster_event_id_player_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_organizer": {
+      "name": "event_organizer",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_eo_event": {
+          "name": "idx_eo_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_organizer_event_id_event_id_fk": {
+          "name": "event_organizer_event_id_event_id_fk",
+          "tableFrom": "event_organizer",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_organizer_organizer_id_organizer_id_fk": {
+          "name": "event_organizer_organizer_id_organizer_id_fk",
+          "tableFrom": "event_organizer",
+          "tableTo": "organizer",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_organizer_event_id_organizer_id_pk": {
+          "columns": [
+            "event_id",
+            "organizer_id"
+          ],
+          "name": "event_organizer_event_id_organizer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_result": {
+      "name": "event_result",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank_to": {
+          "name": "rank_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_amount": {
+          "name": "prize_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_currency": {
+          "name": "prize_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_result_event_id_event_id_fk": {
+          "name": "event_result_event_id_event_id_fk",
+          "tableFrom": "event_result",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_result_team_id_teams_id_fk": {
+          "name": "event_result_team_id_teams_id_fk",
+          "tableFrom": "event_result",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_team": {
+      "name": "event_team",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_team_event_id_event_id_fk": {
+          "name": "event_team_event_id_event_id_fk",
+          "tableFrom": "event_team",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "event_team_team_id_teams_id_fk": {
+          "name": "event_team_team_id_teams_id_fk",
+          "tableFrom": "event_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_team_event_id_team_id_pk": {
+          "columns": [
+            "event_id",
+            "team_id"
+          ],
+          "name": "event_team_event_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_team_player": {
+      "name": "event_team_player",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_etp_event": {
+          "name": "idx_etp_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_team_player_event_id_event_id_fk": {
+          "name": "event_team_player_event_id_event_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_team_player_team_id_teams_id_fk": {
+          "name": "event_team_player_team_id_teams_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_team_player_player_id_player_id_fk": {
+          "name": "event_team_player_player_id_player_id_fk",
+          "tableFrom": "event_team_player",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_team_player_event_id_team_id_player_id_pk": {
+          "columns": [
+            "event_id",
+            "team_id",
+            "player_id"
+          ],
+          "name": "event_team_player_event_id_team_id_player_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_video": {
+      "name": "event_video",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_ev_event": {
+          "name": "idx_ev_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_video_event_id_event_id_fk": {
+          "name": "event_video_event_id_event_id_fk",
+          "tableFrom": "event_video",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_website": {
+      "name": "event_website",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_website_event_id_event_id_fk": {
+          "name": "event_website_event_id_event_id_fk",
+          "tableFrom": "event_website",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizer": {
+      "name": "organizer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "organizer_slug_unique": {
+          "name": "organizer_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "type": {
+          "name": "type",
+          "value": "\"organizer\".\"type\" IS NULL OR \"organizer\".\"type\" IN ('individual', 'organization', 'community', 'tournament_series', 'league')"
+        }
+      }
+    },
+    "organizer_user": {
+      "name": "organizer_user",
+      "columns": {
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizer_user_organizer_id_organizer_id_fk": {
+          "name": "organizer_user_organizer_id_organizer_id_fk",
+          "tableFrom": "organizer_user",
+          "tableTo": "organizer",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organizer_user_user_id_user_id_fk": {
+          "name": "organizer_user_user_id_user_id_fk",
+          "tableFrom": "organizer_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organizer_user_organizer_id_user_id_pk": {
+          "columns": [
+            "organizer_id",
+            "user_id"
+          ],
+          "name": "organizer_user_organizer_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "character": {
+      "name": "character",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "map": {
+      "name": "map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_game_match": {
+          "name": "idx_game_match",
+          "columns": [
+            "match_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_match_id_match_id_fk": {
+          "name": "game_match_id_match_id_fk",
+          "tableFrom": "game",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_map_id_map_id_fk": {
+          "name": "game_map_id_map_id_fk",
+          "tableFrom": "game",
+          "tableTo": "map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_player_score": {
+      "name": "game_player_score",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_first_half": {
+          "name": "character_first_half",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character_second_half": {
+          "name": "character_second_half",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damage_score": {
+          "name": "damage_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knocks": {
+          "name": "knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assists": {
+          "name": "assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "damage": {
+          "name": "damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_gps_game": {
+          "name": "idx_gps_game",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_team": {
+          "name": "idx_gps_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_account": {
+          "name": "idx_gps_account",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_char1": {
+          "name": "idx_gps_char1",
+          "columns": [
+            "character_first_half"
+          ],
+          "isUnique": false
+        },
+        "idx_gps_char2": {
+          "name": "idx_gps_char2",
+          "columns": [
+            "character_second_half"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_player_score_game_id_game_id_fk": {
+          "name": "game_player_score_game_id_game_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_team_id_teams_id_fk": {
+          "name": "game_player_score_team_id_teams_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_character_first_half_character_id_fk": {
+          "name": "game_player_score_character_first_half_character_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_first_half"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_score_character_second_half_character_id_fk": {
+          "name": "game_player_score_character_second_half_character_id_fk",
+          "tableFrom": "game_player_score",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_second_half"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_team": {
+      "name": "game_team",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_gt_game": {
+          "name": "idx_gt_game",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "idx_gt_team": {
+          "name": "idx_gt_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_team_game_id_game_id_fk": {
+          "name": "game_team_game_id_game_id_fk",
+          "tableFrom": "game_team",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_team_team_id_teams_id_fk": {
+          "name": "game_team_team_id_teams_id_fk",
+          "tableFrom": "game_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_team_game_id_team_id_pk": {
+          "columns": [
+            "game_id",
+            "team_id"
+          ],
+          "name": "game_team_game_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "position": {
+          "name": "position",
+          "value": "\"game_team\".\"position\" IN (0, 1)"
+        }
+      }
+    },
+    "game_vod": {
+      "name": "game_vod",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "official": {
+          "name": "official",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available": {
+          "name": "available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_vod_game_id_game_id_fk": {
+          "name": "game_vod_game_id_game_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_vod_player_id_player_id_fk": {
+          "name": "game_vod_player_id_player_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_vod_team_id_teams_id_fk": {
+          "name": "game_vod_team_id_teams_id_fk",
+          "tableFrom": "game_vod",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_vod_game_id_url_pk": {
+          "columns": [
+            "game_id",
+            "url"
+          ],
+          "name": "game_vod_game_id_url_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match": {
+      "name": "match",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_match_stage": {
+          "name": "idx_match_stage",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "format": {
+          "name": "format",
+          "value": "\"match\".\"format\" IN ('BO1', 'BO3', 'BO5')"
+        }
+      }
+    },
+    "match_map": {
+      "name": "match_map",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_picker_position": {
+          "name": "map_picker_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side_picker_position": {
+          "name": "side_picker_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_map_match_id_match_id_fk": {
+          "name": "match_map_match_id_match_id_fk",
+          "tableFrom": "match_map",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_map_map_id_map_id_fk": {
+          "name": "match_map_map_id_map_id_fk",
+          "tableFrom": "match_map",
+          "tableTo": "map",
+          "columnsFrom": [
+            "map_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "match_team": {
+      "name": "match_team",
+      "columns": {
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "match_team_match_id_match_id_fk": {
+          "name": "match_team_match_id_match_id_fk",
+          "tableFrom": "match_team",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "match_team_team_id_teams_id_fk": {
+          "name": "match_team_team_id_teams_id_fk",
+          "tableFrom": "match_team",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "match_team_match_id_team_id_pk": {
+          "columns": [
+            "match_id",
+            "team_id"
+          ],
+          "name": "match_team_match_id_team_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "position": {
+          "name": "position",
+          "value": "\"match_team\".\"position\" >= 0"
+        }
+      }
+    },
+    "event_stage": {
+      "name": "event_stage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_stage_event": {
+          "name": "idx_stage_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_stage_event_id_event_id_fk": {
+          "name": "event_stage_event_id_event_id_fk",
+          "tableFrom": "event_stage",
+          "tableTo": "event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "stage": {
+          "name": "stage",
+          "value": "\"event_stage\".\"stage\" IN ('group', 'qualifier', 'showmatch', 'playoff')"
+        },
+        "format": {
+          "name": "format",
+          "value": "\"event_stage\".\"format\" IN ('single', 'double', 'swiss', 'round-robin')"
+        }
+      }
+    },
+    "stage_node": {
+      "name": "stage_node",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_node_stage_id_event_stage_id_fk": {
+          "name": "stage_node_stage_id_event_stage_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "event_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_match_id_match_id_fk": {
+          "name": "stage_node_match_id_match_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_round_id_stage_round_id_fk": {
+          "name": "stage_node_round_id_stage_round_id_fk",
+          "tableFrom": "stage_node",
+          "tableTo": "stage_round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stage_node_dependency": {
+      "name": "stage_node_dependency",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependency_match_id": {
+          "name": "dependency_match_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_node_dependency_node_id_stage_node_id_fk": {
+          "name": "stage_node_dependency_node_id_stage_node_id_fk",
+          "tableFrom": "stage_node_dependency",
+          "tableTo": "stage_node",
+          "columnsFrom": [
+            "node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stage_node_dependency_dependency_match_id_match_id_fk": {
+          "name": "stage_node_dependency_dependency_match_id_match_id_fk",
+          "tableFrom": "stage_node_dependency",
+          "tableTo": "match",
+          "columnsFrom": [
+            "dependency_match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stage_round": {
+      "name": "stage_round",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bracket": {
+          "name": "bracket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_group": {
+          "name": "parallel_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stage_round_stage_id_event_stage_id_fk": {
+          "name": "stage_round_stage_id_event_stage_id_fk",
+          "tableFrom": "stage_round",
+          "tableTo": "event_stage",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_mouse_settings": {
+      "name": "player_mouse_settings",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dpi": {
+          "name": "dpi",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitivity": {
+          "name": "sensitivity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "polling_rate_hz": {
+          "name": "polling_rate_hz",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "windows_pointer_speed": {
+          "name": "windows_pointer_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mouse_smoothing": {
+          "name": "mouse_smoothing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mouse_model": {
+          "name": "mouse_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vertical_sens_multiplier": {
+          "name": "vertical_sens_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shoulder_fire_sens_multiplier": {
+          "name": "shoulder_fire_sens_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_1_25x": {
+          "name": "ads_sens_1_25x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_1_5x": {
+          "name": "ads_sens_1_5x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_2_5x": {
+          "name": "ads_sens_2_5x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ads_sens_4_0x": {
+          "name": "ads_sens_4_0x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_mouse_settings_player_id_player_id_fk": {
+          "name": "player_mouse_settings_player_id_player_id_fk",
+          "tableFrom": "player_mouse_settings",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_character_stats": {
+      "name": "player_character_stats",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "superstring_power": {
+          "name": "superstring_power",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_game_at": {
+          "name": "last_game_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_pcs_player": {
+          "name": "idx_pcs_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcs_character": {
+          "name": "idx_pcs_character",
+          "columns": [
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcs_player_total_games": {
+          "name": "idx_pcs_player_total_games",
+          "columns": [
+            "player_id",
+            "total_games",
+            "superstring_power",
+            "total_wins"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_character_stats_player_id_player_id_fk": {
+          "name": "player_character_stats_player_id_player_id_fk",
+          "tableFrom": "player_character_stats",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "player_character_stats_character_id_character_id_fk": {
+          "name": "player_character_stats_character_id_character_id_fk",
+          "tableFrom": "player_character_stats",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_character_stats_player_id_character_id_pk": {
+          "columns": [
+            "player_id",
+            "character_id"
+          ],
+          "name": "player_character_stats_player_id_character_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_character_stats_history": {
+      "name": "player_character_stats_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superstring_power": {
+          "name": "superstring_power",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_pcsh_player": {
+          "name": "idx_pcsh_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_character": {
+          "name": "idx_pcsh_character",
+          "columns": [
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_snapshot": {
+          "name": "idx_pcsh_snapshot",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_player_character": {
+          "name": "idx_pcsh_player_character",
+          "columns": [
+            "player_id",
+            "character_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pcsh_player_snapshot": {
+          "name": "idx_pcsh_player_snapshot",
+          "columns": [
+            "player_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_character_stats_history_player_id_player_id_fk": {
+          "name": "player_character_stats_history_player_id_player_id_fk",
+          "tableFrom": "player_character_stats_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "player_character_stats_history_character_id_character_id_fk": {
+          "name": "player_character_stats_history_character_id_character_id_fk",
+          "tableFrom": "player_character_stats_history",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_stats": {
+      "name": "player_stats",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "player_rating": {
+          "name": "player_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "events_count": {
+          "name": "events_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_game_at": {
+          "name": "last_game_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_stats_player_id_player_id_fk": {
+          "name": "player_stats_player_id_player_id_fk",
+          "tableFrom": "player_stats",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_stats_history": {
+      "name": "player_stats_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_games": {
+          "name": "total_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_wins": {
+          "name": "total_wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_losses": {
+          "name": "total_losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_kills": {
+          "name": "total_kills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_deaths": {
+          "name": "total_deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_assists": {
+          "name": "total_assists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_knocks": {
+          "name": "total_knocks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_damage": {
+          "name": "total_damage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "win_rate": {
+          "name": "win_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kd": {
+          "name": "kd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_damage": {
+          "name": "average_damage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_rating": {
+          "name": "player_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events_count": {
+          "name": "events_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_psh_player": {
+          "name": "idx_psh_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_psh_snapshot": {
+          "name": "idx_psh_snapshot",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_psh_player_snapshot": {
+          "name": "idx_psh_player_snapshot",
+          "columns": [
+            "player_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_stats_history_player_id_player_id_fk": {
+          "name": "player_stats_history_player_id_player_id_fk",
+          "tableFrom": "player_stats_history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "edit_history": {
+      "name": "edit_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_eh_table": {
+          "name": "idx_eh_table",
+          "columns": [
+            "table_name"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_record": {
+          "name": "idx_eh_record",
+          "columns": [
+            "record_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_edited_by": {
+          "name": "idx_eh_edited_by",
+          "columns": [
+            "edited_by"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_edited_at": {
+          "name": "idx_eh_edited_at",
+          "columns": [
+            "edited_at"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_table_record": {
+          "name": "idx_eh_table_record",
+          "columns": [
+            "table_name",
+            "record_id"
+          ],
+          "isUnique": false
+        },
+        "idx_eh_table_edited_at": {
+          "name": "idx_eh_table_edited_at",
+          "columns": [
+            "table_name",
+            "edited_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "edit_history_edited_by_user_id_fk": {
+          "name": "edit_history_edited_by_user_id_fk",
+          "tableFrom": "edit_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "edited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_tag": {
+      "name": "community_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_ct_category": {
+          "name": "idx_ct_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_ct_category_value": {
+          "name": "idx_ct_category_value",
+          "columns": [
+            "category",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discord_server": {
+      "name": "discord_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "additional_link_text": {
+          "name": "additional_link_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_link_url": {
+          "name": "additional_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discord_server_tag": {
+      "name": "discord_server_tag",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "idx_dst_server": {
+          "name": "idx_dst_server",
+          "columns": [
+            "server_id"
+          ],
+          "isUnique": false
+        },
+        "idx_dst_tag": {
+          "name": "idx_dst_tag",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "discord_server_tag_server_id_discord_server_id_fk": {
+          "name": "discord_server_tag_server_id_discord_server_id_fk",
+          "tableFrom": "discord_server_tag",
+          "tableTo": "discord_server",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discord_server_tag_tag_id_community_tag_id_fk": {
+          "name": "discord_server_tag_tag_id_community_tag_id_fk",
+          "tableFrom": "discord_server_tag",
+          "tableTo": "community_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "discord_server_tag_server_id_tag_id_pk": {
+          "columns": [
+            "server_id",
+            "tag_id"
+          ],
+          "name": "discord_server_tag_server_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deleted_record": {
+      "name": "deleted_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deleted_record_entity": {
+          "name": "idx_deleted_record_entity",
+          "columns": [
+            "entity"
+          ],
+          "isUnique": false
+        },
+        "idx_deleted_record_record": {
+          "name": "idx_deleted_record_record",
+          "columns": [
+            "record_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deleted_record_deleted_by_user_id_fk": {
+          "name": "deleted_record_deleted_by_user_id_fk",
+          "tableFrom": "deleted_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1780210892302,
       "tag": "0003_lumpy_rachel_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1780212534588,
+      "tag": "0004_married_jasper_sitwell",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -915,5 +915,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -919,5 +919,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -915,5 +915,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -915,5 +915,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -909,5 +909,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -909,5 +909,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -909,5 +909,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -915,5 +915,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -927,5 +927,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/uk-ua.json
+++ b/messages/uk-ua.json
@@ -927,5 +927,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -909,5 +909,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/zh-tw.json
+++ b/messages/zh-tw.json
@@ -909,5 +909,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -909,5 +909,16 @@
 	"mcp_log_prev": "Previous",
 	"mcp_log_next": "Next",
 	"mcp_log_page_of": "Page {page} of {total}",
-	"mcp_log_apply": "Apply"
+	"mcp_log_apply": "Apply",
+	"oauth_authorize_title": "Authorize access",
+	"oauth_authorize_app_wants": "{app} wants to access your LemonTV account",
+	"oauth_authorize_unknown_app": "An application",
+	"oauth_authorize_signed_in_as": "Signed in as {username}",
+	"oauth_authorize_permissions": "This will allow it to:",
+	"oauth_scope_read": "Read data — tournaments, teams, players, and matches",
+	"oauth_scope_write": "Write data — create and edit content (requires an editor role)",
+	"oauth_authorize_button": "Authorize",
+	"oauth_deny_button": "Deny",
+	"oauth_authorize_error_title": "Authorization error",
+	"oauth_authorize_review_note": "Only authorize applications you trust — they will act on your behalf via the MCP API."
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -24,6 +24,50 @@ export const init: ServerInit = async () => {
 	}
 };
 
+// OAuth machine endpoints that legitimately receive cross-origin form-encoded
+// POSTs from public clients. They carry no ambient cookie credentials (security
+// comes from the PKCE code / refresh token), so the origin-CSRF check does not
+// apply to them — they are the reason the global check is disabled.
+const CSRF_EXEMPT_PATHS = ['/oauth/token', '/oauth/register'];
+
+const FORM_CONTENT_TYPES = [
+	'application/x-www-form-urlencoded',
+	'multipart/form-data',
+	'text/plain'
+];
+
+function isFormContentType(request: Request): boolean {
+	const ct = (request.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
+	return FORM_CONTENT_TYPES.includes(ct);
+}
+
+// Re-implements SvelteKit's disabled built-in origin check (turned off globally
+// in svelte.config.js so the OAuth endpoints can accept cross-origin form posts).
+// This restores identical protection for every OTHER route: a mutating
+// form-encoded request whose Origin doesn't match this site is rejected. Mirrors
+// upstream by skipping the check in dev.
+const handleCsrf: Handle = ({ event, resolve }) => {
+	if (dev) return resolve(event);
+
+	const { request, url } = event;
+	const mutating =
+		request.method === 'POST' ||
+		request.method === 'PUT' ||
+		request.method === 'PATCH' ||
+		request.method === 'DELETE';
+
+	if (mutating && isFormContentType(request) && !CSRF_EXEMPT_PATHS.includes(url.pathname)) {
+		const origin = request.headers.get('origin');
+		if (origin !== url.origin) {
+			return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
+				status: 403
+			});
+		}
+	}
+
+	return resolve(event);
+};
+
 const handleParaglide: Handle = ({ event, resolve }) => {
 	// Skip localization for specific paths
 	const excludedPaths = ['/sitemap.xml', '/api/'];
@@ -113,4 +157,4 @@ const handleJWKS: Handle = ({ event, resolve }) => {
 	return resolve(event);
 };
 
-export const handle: Handle = sequence(handleParaglide, handleAuth, handleJWKS);
+export const handle: Handle = sequence(handleCsrf, handleParaglide, handleAuth, handleJWKS);

--- a/src/lib/server/db/schemas/auth/index.ts
+++ b/src/lib/server/db/schemas/auth/index.ts
@@ -6,3 +6,4 @@ export * from './mcp-audit-log';
 export * from './mcp-rate-limit';
 export * from './oauth-client';
 export * from './oauth-auth-code';
+export * from './oauth-refresh-token';

--- a/src/lib/server/db/schemas/auth/oauth-refresh-token.ts
+++ b/src/lib/server/db/schemas/auth/oauth-refresh-token.ts
@@ -1,0 +1,39 @@
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { user } from './user';
+import { oauthClient } from './oauth-client';
+
+/**
+ * OAuth refresh tokens for the MCP flow. Single-use and ROTATED: every refresh
+ * exchange consumes the presented token (`consumedAt` set under a
+ * `WHERE consumedAt IS NULL` guard) and issues a fresh one. Only the SHA-256
+ * hash of the opaque token is stored. Bound to client + user + granted scope +
+ * resource so a refresh can never widen scope or change audience.
+ */
+export const oauthRefreshToken = sqliteTable(
+	'oauth_refresh_token',
+	{
+		id: text('id').primaryKey(),
+		tokenHash: text('token_hash').notNull().unique(),
+		clientId: text('client_id')
+			.notNull()
+			.references(() => oauthClient.id, { onDelete: 'cascade' }),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id),
+		scope: text('scope').notNull(),
+		resource: text('resource').notNull(),
+		expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+		consumedAt: integer('consumed_at', { mode: 'timestamp' }),
+		createdAt: integer('created_at', { mode: 'timestamp' }).notNull()
+	},
+	(table) => {
+		return {
+			idx_client: index('idx_oauth_refresh_client').on(table.clientId),
+			idx_user: index('idx_oauth_refresh_user').on(table.userId),
+			idx_expires: index('idx_oauth_refresh_expires').on(table.expiresAt)
+		};
+	}
+);
+
+export type OAuthRefreshToken = typeof oauthRefreshToken.$inferSelect;
+export type NewOAuthRefreshToken = typeof oauthRefreshToken.$inferInsert;

--- a/src/lib/server/oauth/authorize-core.test.ts
+++ b/src/lib/server/oauth/authorize-core.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'bun:test';
+import { checkAuthorizeParams, buildRedirect, type AuthorizeParams } from './authorize-core';
+import { MCP_RESOURCE } from './config';
+
+const REGISTERED = ['https://app.example/cb'];
+const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'; // 43 chars
+
+function params(overrides: Partial<AuthorizeParams> = {}): AuthorizeParams {
+	return {
+		responseType: 'code',
+		clientId: 'client-1',
+		redirectUri: 'https://app.example/cb',
+		codeChallenge: CHALLENGE,
+		codeChallengeMethod: 'S256',
+		scope: 'mcp:read mcp:write',
+		state: 'xyz',
+		resource: MCP_RESOURCE,
+		...overrides
+	};
+}
+
+describe('checkAuthorizeParams — pre-redirect gate (no redirect on these)', () => {
+	it('invalid when client_id missing', () => {
+		const r = checkAuthorizeParams(params({ clientId: null }), REGISTERED);
+		expect(r.status).toBe('invalid');
+	});
+	it('invalid when redirect_uri missing', () => {
+		const r = checkAuthorizeParams(params({ redirectUri: null }), REGISTERED);
+		expect(r.status).toBe('invalid');
+	});
+	it('invalid when redirect_uri does not match a registered URI', () => {
+		const r = checkAuthorizeParams(params({ redirectUri: 'https://app.example/evil' }), REGISTERED);
+		expect(r.status).toBe('invalid');
+	});
+	it('invalid when client is unknown (no registered URIs)', () => {
+		const r = checkAuthorizeParams(params(), []);
+		expect(r.status).toBe('invalid');
+	});
+});
+
+describe('checkAuthorizeParams — post-gate errors redirect back', () => {
+	it('unsupported_response_type', () => {
+		const r = checkAuthorizeParams(params({ responseType: 'token' }), REGISTERED);
+		expect(r.status).toBe('redirect_error');
+		if (r.status === 'redirect_error') expect(r.error).toBe('unsupported_response_type');
+	});
+	it('requires PKCE code_challenge', () => {
+		const r = checkAuthorizeParams(params({ codeChallenge: null }), REGISTERED);
+		expect(r.status).toBe('redirect_error');
+		if (r.status === 'redirect_error') expect(r.error).toBe('invalid_request');
+	});
+	it('rejects non-S256 (and absent) code_challenge_method', () => {
+		expect(checkAuthorizeParams(params({ codeChallengeMethod: 'plain' }), REGISTERED).status).toBe(
+			'redirect_error'
+		);
+		expect(checkAuthorizeParams(params({ codeChallengeMethod: null }), REGISTERED).status).toBe(
+			'redirect_error'
+		);
+	});
+	it('rejects unsupported scope', () => {
+		const r = checkAuthorizeParams(params({ scope: 'mcp:read admin' }), REGISTERED);
+		expect(r.status).toBe('redirect_error');
+		if (r.status === 'redirect_error') expect(r.error).toBe('invalid_scope');
+	});
+	it('rejects a resource other than the MCP resource', () => {
+		const r = checkAuthorizeParams(params({ resource: 'https://lemontv.win/other' }), REGISTERED);
+		expect(r.status).toBe('redirect_error');
+		if (r.status === 'redirect_error') expect(r.error).toBe('invalid_target');
+	});
+});
+
+describe('checkAuthorizeParams — success', () => {
+	it('passes a well-formed request and normalizes scope', () => {
+		const r = checkAuthorizeParams(params(), REGISTERED);
+		expect(r.status).toBe('ok');
+		if (r.status === 'ok') {
+			expect(r.scopes).toEqual(['mcp:read', 'mcp:write']);
+			expect(r.resource).toBe(MCP_RESOURCE);
+			expect(r.codeChallenge).toBe(CHALLENGE);
+			expect(r.state).toBe('xyz');
+		}
+	});
+	it('defaults scope to mcp:read and resource to the MCP resource when omitted', () => {
+		const r = checkAuthorizeParams(params({ scope: null, resource: null }), REGISTERED);
+		expect(r.status).toBe('ok');
+		if (r.status === 'ok') {
+			expect(r.scopes).toEqual(['mcp:read']);
+			expect(r.resource).toBe(MCP_RESOURCE);
+		}
+	});
+});
+
+describe('buildRedirect', () => {
+	it('appends params and preserves existing query', () => {
+		const out = buildRedirect('https://app.example/cb?foo=1', { code: 'abc', state: 'xyz' });
+		const u = new URL(out);
+		expect(u.searchParams.get('foo')).toBe('1');
+		expect(u.searchParams.get('code')).toBe('abc');
+		expect(u.searchParams.get('state')).toBe('xyz');
+	});
+	it('skips null/undefined params (e.g. absent state)', () => {
+		const out = buildRedirect('https://app.example/cb', { error: 'access_denied', state: null });
+		const u = new URL(out);
+		expect(u.searchParams.get('error')).toBe('access_denied');
+		expect(u.searchParams.has('state')).toBe(false);
+	});
+});

--- a/src/lib/server/oauth/authorize-core.ts
+++ b/src/lib/server/oauth/authorize-core.ts
@@ -1,0 +1,126 @@
+/**
+ * /authorize request validation (RFC 6749 §4.1.1 + PKCE + RFC 8707) — pure.
+ *
+ * The redirect-URI decision gate is the security-critical part:
+ *  - If client_id is unknown OR redirect_uri doesn't EXACTLY match one the client
+ *    registered, we must NOT redirect (could leak codes to an attacker URI) →
+ *    status 'invalid' (render an error page).
+ *  - Once the redirect_uri is trusted, every other failure is reported by
+ *    redirecting back to it with an `error` param → status 'redirect_error'.
+ */
+import { redirectUriMatches } from './pkce';
+import { parseScope, allScopesSupported } from './scope';
+import { MCP_RESOURCE, DEFAULT_SCOPE } from './config';
+
+export interface AuthorizeParams {
+	responseType: string | null;
+	clientId: string | null;
+	redirectUri: string | null;
+	codeChallenge: string | null;
+	codeChallengeMethod: string | null;
+	scope: string | null;
+	state: string | null;
+	resource: string | null;
+}
+
+export type AuthorizeCheck =
+	| { status: 'invalid'; error: string; description: string }
+	| {
+			status: 'redirect_error';
+			error: string;
+			description: string;
+			redirectUri: string;
+			state: string | null;
+	  }
+	| {
+			status: 'ok';
+			redirectUri: string;
+			scopes: string[];
+			scope: string;
+			resource: string;
+			codeChallenge: string;
+			state: string | null;
+	  };
+
+/**
+ * @param registeredRedirectUris the client's registered URIs (empty if the
+ *   client_id is unknown — which forces a non-redirecting 'invalid').
+ */
+export function checkAuthorizeParams(
+	p: AuthorizeParams,
+	registeredRedirectUris: readonly string[]
+): AuthorizeCheck {
+	// --- Pre-redirect gate: client_id + redirect_uri must be trusted first. ---
+	if (!p.clientId) {
+		return { status: 'invalid', error: 'invalid_request', description: 'missing client_id' };
+	}
+	if (!p.redirectUri) {
+		return { status: 'invalid', error: 'invalid_request', description: 'missing redirect_uri' };
+	}
+	if (!redirectUriMatches(registeredRedirectUris, p.redirectUri)) {
+		return {
+			status: 'invalid',
+			error: 'invalid_request',
+			description: 'unknown client or redirect_uri does not match a registered URI'
+		};
+	}
+
+	const redirectUri = p.redirectUri;
+	const state = p.state;
+	const rejectViaRedirect = (error: string, description: string): AuthorizeCheck => ({
+		status: 'redirect_error',
+		error,
+		description,
+		redirectUri,
+		state
+	});
+
+	// --- Post-gate: errors are now safe to deliver to the trusted redirect_uri. ---
+	if (p.responseType !== 'code') {
+		return rejectViaRedirect('unsupported_response_type', 'response_type must be "code"');
+	}
+	if (!p.codeChallenge) {
+		return rejectViaRedirect('invalid_request', 'code_challenge is required (PKCE)');
+	}
+	// PKCE: S256 only. Absent method defaults to "plain" in RFC 7636 — which we reject.
+	if (p.codeChallengeMethod !== 'S256') {
+		return rejectViaRedirect('invalid_request', 'code_challenge_method must be S256');
+	}
+	if (p.codeChallenge.length < 43 || p.codeChallenge.length > 128) {
+		return rejectViaRedirect('invalid_request', 'malformed code_challenge');
+	}
+
+	let scopes = parseScope(p.scope);
+	if (scopes.length === 0) scopes = parseScope(DEFAULT_SCOPE);
+	if (!allScopesSupported(scopes)) {
+		return rejectViaRedirect('invalid_scope', 'requested scope is not supported');
+	}
+
+	// RFC 8707: if a resource is named it must be exactly our MCP resource.
+	const resource = p.resource ?? MCP_RESOURCE;
+	if (resource !== MCP_RESOURCE) {
+		return rejectViaRedirect('invalid_target', 'resource must be the MCP resource');
+	}
+
+	return {
+		status: 'ok',
+		redirectUri,
+		scopes,
+		scope: scopes.join(' '),
+		resource,
+		codeChallenge: p.codeChallenge,
+		state
+	};
+}
+
+/** Build an absolute redirect URL with appended query params, preserving existing ones. */
+export function buildRedirect(
+	redirectUri: string,
+	params: Record<string, string | null | undefined>
+): string {
+	const url = new URL(redirectUri);
+	for (const [k, v] of Object.entries(params)) {
+		if (v !== null && v !== undefined) url.searchParams.set(k, v);
+	}
+	return url.toString();
+}

--- a/src/lib/server/oauth/config.ts
+++ b/src/lib/server/oauth/config.ts
@@ -23,13 +23,24 @@ export type OAuthScope = (typeof OAUTH_SCOPES_SUPPORTED)[number];
 
 export const PKCE_METHODS_SUPPORTED = ['S256'] as const;
 export const OAUTH_RESPONSE_TYPES_SUPPORTED = ['code'] as const;
-export const OAUTH_GRANT_TYPES_SUPPORTED = ['authorization_code'] as const;
+export const OAUTH_GRANT_TYPES_SUPPORTED = ['authorization_code', 'refresh_token'] as const;
 export const TOKEN_ENDPOINT_AUTH_METHODS = ['none'] as const; // public (PKCE) clients
 
 /** Authorization codes are single-use and very short-lived. */
 export const AUTH_CODE_TTL_MS = 60_000;
-/** Access tokens are short-lived; longevity comes from re-running the flow (refresh tokens: PR B). */
+/** Access tokens are short-lived; longevity comes from refresh-token rotation. */
 export const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+/** Refresh tokens are long-lived but single-use (rotated on every exchange). */
+export const REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+/** Grant types the token endpoint actually implements. */
+export const OAUTH_TOKEN_GRANT_TYPES = ['authorization_code', 'refresh_token'] as const;
+
+/** Default scope when an `/authorize` request omits `scope` — least privilege. */
+export const DEFAULT_SCOPE = 'mcp:read';
+
+/** Cap on redirect URIs a single dynamically-registered client may declare. */
+export const MAX_REDIRECT_URIS = 10;
 
 /** Signing key id — reuses the existing ES256 key served at /.well-known/jwks.json. */
 export const JWT_KID = 'lemon-key';

--- a/src/lib/server/oauth/dcr-core.test.ts
+++ b/src/lib/server/oauth/dcr-core.test.ts
@@ -57,6 +57,11 @@ describe('validateDcrRequest', () => {
 		expect(validateDcrRequest({ redirect_uris: many }).ok).toBe(false);
 	});
 
+	it('rejects an over-long redirect_uri (DoS guard)', () => {
+		const huge = 'https://app.example/cb?x=' + 'a'.repeat(3000);
+		expect(validateDcrRequest({ redirect_uris: [huge] }).ok).toBe(false);
+	});
+
 	it('rejects non-https client_uri / logo_uri', () => {
 		expect(validateDcrRequest({ redirect_uris: ['https://a/cb'], client_uri: 'http://x' }).ok).toBe(
 			false

--- a/src/lib/server/oauth/dcr-core.test.ts
+++ b/src/lib/server/oauth/dcr-core.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'bun:test';
+import { validateDcrRequest } from './dcr-core';
+
+describe('validateDcrRequest', () => {
+	it('accepts a minimal valid public client', () => {
+		const r = validateDcrRequest({ redirect_uris: ['https://app.example/cb'] });
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value.redirectUris).toEqual(['https://app.example/cb']);
+	});
+
+	it('accepts loopback http redirect URIs (native clients)', () => {
+		const r = validateDcrRequest({
+			redirect_uris: ['http://127.0.0.1:1234/cb', 'http://localhost:55000/callback'],
+			client_name: 'Claude Code'
+		});
+		expect(r.ok).toBe(true);
+	});
+
+	it('rejects missing or empty redirect_uris', () => {
+		expect(validateDcrRequest({}).ok).toBe(false);
+		expect(validateDcrRequest({ redirect_uris: [] }).ok).toBe(false);
+		expect(validateDcrRequest({ redirect_uris: 'https://x/cb' }).ok).toBe(false);
+	});
+
+	it('rejects non-loopback http and fragments', () => {
+		expect(validateDcrRequest({ redirect_uris: ['http://evil.example/cb'] }).ok).toBe(false);
+		expect(validateDcrRequest({ redirect_uris: ['https://app.example/cb#x'] }).ok).toBe(false);
+	});
+
+	it('rejects confidential auth methods (public clients only)', () => {
+		const r = validateDcrRequest({
+			redirect_uris: ['https://app.example/cb'],
+			token_endpoint_auth_method: 'client_secret_basic'
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('accepts token_endpoint_auth_method "none"', () => {
+		const r = validateDcrRequest({
+			redirect_uris: ['https://app.example/cb'],
+			token_endpoint_auth_method: 'none'
+		});
+		expect(r.ok).toBe(true);
+	});
+
+	it('rejects unsupported grant/response types', () => {
+		expect(
+			validateDcrRequest({ redirect_uris: ['https://a/cb'], grant_types: ['password'] }).ok
+		).toBe(false);
+		expect(
+			validateDcrRequest({ redirect_uris: ['https://a/cb'], response_types: ['token'] }).ok
+		).toBe(false);
+	});
+
+	it('rejects too many redirect_uris', () => {
+		const many = Array.from({ length: 11 }, (_, i) => `https://app.example/cb${i}`);
+		expect(validateDcrRequest({ redirect_uris: many }).ok).toBe(false);
+	});
+
+	it('rejects non-https client_uri / logo_uri', () => {
+		expect(validateDcrRequest({ redirect_uris: ['https://a/cb'], client_uri: 'http://x' }).ok).toBe(
+			false
+		);
+		expect(validateDcrRequest({ redirect_uris: ['https://a/cb'], logo_uri: 'ftp://x' }).ok).toBe(
+			false
+		);
+	});
+});

--- a/src/lib/server/oauth/dcr-core.ts
+++ b/src/lib/server/oauth/dcr-core.ts
@@ -1,0 +1,129 @@
+/**
+ * Dynamic Client Registration request validation (RFC 7591) — pure.
+ *
+ * MCP clients are PUBLIC: the only auth method we accept is `none` (PKCE). We
+ * validate redirect URIs strictly (https or loopback http, no fragment) because
+ * everything downstream — exact-match at /authorize and /token — trusts them.
+ */
+import { isAcceptableRedirectUri } from './pkce';
+import { MAX_REDIRECT_URIS } from './config';
+
+export interface DcrRequestBody {
+	redirect_uris?: unknown;
+	client_name?: unknown;
+	client_uri?: unknown;
+	logo_uri?: unknown;
+	scope?: unknown;
+	software_id?: unknown;
+	grant_types?: unknown;
+	response_types?: unknown;
+	token_endpoint_auth_method?: unknown;
+}
+
+export interface DcrMetadata {
+	redirectUris: string[];
+	clientName: string | null;
+	clientUri: string | null;
+	logoUri: string | null;
+	scope: string | null;
+	softwareId: string | null;
+}
+
+export type DcrResult =
+	| { ok: true; value: DcrMetadata }
+	| { ok: false; error: string; description: string };
+
+const MAX_STR = 2048;
+
+function optionalString(value: unknown): string | null | undefined {
+	// undefined -> field absent (ok); null/wrong-type -> invalid; '' -> treated as absent
+	if (value === undefined) return undefined;
+	if (typeof value !== 'string') return null;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return undefined;
+	if (trimmed.length > MAX_STR) return null;
+	return trimmed;
+}
+
+function isHttpsUri(value: string): boolean {
+	try {
+		return new URL(value).protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+export function validateDcrRequest(body: DcrRequestBody): DcrResult {
+	const invalid = (description: string, error = 'invalid_client_metadata'): DcrResult => ({
+		ok: false,
+		error,
+		description
+	});
+
+	// redirect_uris — required, non-empty array of acceptable URIs.
+	const uris = body.redirect_uris;
+	if (!Array.isArray(uris) || uris.length === 0) {
+		return invalid(
+			'redirect_uris is required and must be a non-empty array',
+			'invalid_redirect_uri'
+		);
+	}
+	if (uris.length > MAX_REDIRECT_URIS) {
+		return invalid(`too many redirect_uris (max ${MAX_REDIRECT_URIS})`, 'invalid_redirect_uri');
+	}
+	const redirectUris: string[] = [];
+	for (const uri of uris) {
+		if (typeof uri !== 'string' || !isAcceptableRedirectUri(uri)) {
+			return invalid(
+				`invalid redirect_uri: ${typeof uri === 'string' ? uri : typeof uri} (must be https, or http on localhost/127.0.0.1, with no fragment)`,
+				'invalid_redirect_uri'
+			);
+		}
+		redirectUris.push(uri);
+	}
+
+	// token_endpoint_auth_method — only public clients ('none').
+	if (body.token_endpoint_auth_method !== undefined && body.token_endpoint_auth_method !== 'none') {
+		return invalid('only token_endpoint_auth_method "none" (public client) is supported');
+	}
+
+	// grant_types / response_types — must be subsets of what we implement.
+	if (body.grant_types !== undefined) {
+		if (
+			!Array.isArray(body.grant_types) ||
+			!body.grant_types.every((g) => g === 'authorization_code' || g === 'refresh_token')
+		) {
+			return invalid('unsupported grant_types (only authorization_code, refresh_token)');
+		}
+	}
+	if (body.response_types !== undefined) {
+		if (!Array.isArray(body.response_types) || !body.response_types.every((r) => r === 'code')) {
+			return invalid('unsupported response_types (only "code")');
+		}
+	}
+
+	const clientName = optionalString(body.client_name);
+	if (clientName === null) return invalid('client_name must be a string');
+	const clientUri = optionalString(body.client_uri);
+	if (clientUri === null) return invalid('client_uri must be a string');
+	if (clientUri && !isHttpsUri(clientUri)) return invalid('client_uri must be https');
+	const logoUri = optionalString(body.logo_uri);
+	if (logoUri === null) return invalid('logo_uri must be a string');
+	if (logoUri && !isHttpsUri(logoUri)) return invalid('logo_uri must be https');
+	const scope = optionalString(body.scope);
+	if (scope === null) return invalid('scope must be a string');
+	const softwareId = optionalString(body.software_id);
+	if (softwareId === null) return invalid('software_id must be a string');
+
+	return {
+		ok: true,
+		value: {
+			redirectUris,
+			clientName: clientName ?? null,
+			clientUri: clientUri ?? null,
+			logoUri: logoUri ?? null,
+			scope: scope ?? null,
+			softwareId: softwareId ?? null
+		}
+	};
+}

--- a/src/lib/server/oauth/dcr-core.ts
+++ b/src/lib/server/oauth/dcr-core.ts
@@ -73,7 +73,7 @@ export function validateDcrRequest(body: DcrRequestBody): DcrResult {
 	}
 	const redirectUris: string[] = [];
 	for (const uri of uris) {
-		if (typeof uri !== 'string' || !isAcceptableRedirectUri(uri)) {
+		if (typeof uri !== 'string' || uri.length > MAX_STR || !isAcceptableRedirectUri(uri)) {
 			return invalid(
 				`invalid redirect_uri: ${typeof uri === 'string' ? uri : typeof uri} (must be https, or http on localhost/127.0.0.1, with no fragment)`,
 				'invalid_redirect_uri'

--- a/src/lib/server/oauth/identity.ts
+++ b/src/lib/server/oauth/identity.ts
@@ -4,7 +4,12 @@
  * Verifies the JWT (aud-bound to the MCP resource), then loads the user and
  * their CURRENT roles from the DB — roles are never trusted from the token, so
  * de-authorizing an editor instantly defangs outstanding tokens (matching the
- * PAT path). Write requires BOTH the `mcp:write` scope AND a live editor/admin role.
+ * PAT path).
+ *
+ * Scope gate (least privilege): a token MUST carry `mcp:read` to get any access
+ * (the dispatcher serves tools/list + every read tool to any returned identity,
+ * so a scope-less token must be rejected, not silently granted read). `mcp:write`
+ * implies read. Write additionally requires a live editor/admin role.
  */
 import { eq } from 'drizzle-orm';
 import { db } from '$lib/server/db';
@@ -12,6 +17,7 @@ import * as table from '$lib/server/db/schema';
 import type { UserRole } from '$lib/data/user';
 import type { McpIdentity } from '$lib/server/mcp/server';
 import { MCP_WRITE_ROLES } from '$lib/server/security/mcp-token';
+import { parseScope } from './scope';
 import { verifyAccessToken } from './token';
 
 export async function identityFromOAuthToken(jwt: string): Promise<McpIdentity | null> {
@@ -30,7 +36,12 @@ export async function identityFromOAuthToken(jwt: string): Promise<McpIdentity |
 		.where(eq(table.userRole.userId, owner.id));
 	const roles = roleRows.map((r) => r.roleId as UserRole);
 
-	const hasWriteScope = claims.scope.split(' ').includes('mcp:write');
+	const scopes = parseScope(claims.scope);
+	const hasWriteScope = scopes.includes('mcp:write');
+	// mcp:write implies read. A token granting neither has no MCP access at all.
+	const hasReadScope = hasWriteScope || scopes.includes('mcp:read');
+	if (!hasReadScope) return null;
+
 	const canWrite = hasWriteScope && MCP_WRITE_ROLES.some((role) => roles.includes(role));
 
 	return {

--- a/src/lib/server/oauth/redirect.test.ts
+++ b/src/lib/server/oauth/redirect.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test';
+import { safeInternalPath } from './redirect';
+
+describe('safeInternalPath', () => {
+	it('allows same-origin absolute paths (with query/hash)', () => {
+		expect(safeInternalPath('/oauth/authorize?client_id=x&state=y')).toBe(
+			'/oauth/authorize?client_id=x&state=y'
+		);
+		expect(safeInternalPath('/')).toBe('/');
+		expect(safeInternalPath('/admin#section')).toBe('/admin#section');
+	});
+
+	it('falls back for absolute URLs (open-redirect)', () => {
+		expect(safeInternalPath('https://evil.example/x')).toBe('/');
+		expect(safeInternalPath('http://evil.example')).toBe('/');
+	});
+
+	it('falls back for protocol-relative and backslash tricks', () => {
+		expect(safeInternalPath('//evil.example')).toBe('/');
+		expect(safeInternalPath('/\\evil.example')).toBe('/');
+	});
+
+	it('falls back for non-path, empty, and null', () => {
+		expect(safeInternalPath('javascript:alert(1)')).toBe('/');
+		expect(safeInternalPath('evil.example')).toBe('/');
+		expect(safeInternalPath('')).toBe('/');
+		expect(safeInternalPath(null)).toBe('/');
+		expect(safeInternalPath(undefined)).toBe('/');
+	});
+
+	it('falls back for paths with control characters (header splitting)', () => {
+		expect(safeInternalPath('/a\nSet-Cookie: x')).toBe('/');
+		expect(safeInternalPath('/a\r\nLocation: https://evil')).toBe('/');
+	});
+
+	it('honours a custom fallback', () => {
+		expect(safeInternalPath(null, '/home')).toBe('/home');
+		expect(safeInternalPath('https://evil', '/home')).toBe('/home');
+	});
+});

--- a/src/lib/server/oauth/redirect.ts
+++ b/src/lib/server/oauth/redirect.ts
@@ -1,0 +1,27 @@
+/**
+ * Same-origin path guard — pure. Prevents the login `?redirect=` parameter from
+ * being abused as an open redirect (e.g. `?redirect=https://evil.example`). Only
+ * a path on our OWN origin is allowed; anything else falls back to `/`.
+ *
+ * This matters more now that `/login?redirect=/oauth/authorize?…` is the gateway
+ * into the OAuth authorization flow.
+ */
+
+/** True if the string contains any C0 control char (NUL..US) — header-splitting guard. */
+function hasControlChar(value: string): boolean {
+	for (let i = 0; i < value.length; i++) {
+		if (value.charCodeAt(i) < 0x20) return true;
+	}
+	return false;
+}
+
+export function safeInternalPath(value: string | null | undefined, fallback = '/'): string {
+	if (!value) return fallback;
+	// Must be an absolute path on this origin: a single leading slash.
+	if (value[0] !== '/') return fallback;
+	// Reject protocol-relative ("//host") and backslash tricks ("/\\host") that
+	// browsers may treat as a new origin.
+	if (value[1] === '/' || value[1] === '\\') return fallback;
+	if (hasControlChar(value)) return fallback;
+	return value;
+}

--- a/src/lib/server/oauth/scope.test.ts
+++ b/src/lib/server/oauth/scope.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'bun:test';
+import { parseScope, allScopesSupported, isSubsetScope, serializeScope } from './scope';
+
+describe('parseScope', () => {
+	it('splits on whitespace and drops empties', () => {
+		expect(parseScope('mcp:read mcp:write')).toEqual(['mcp:read', 'mcp:write']);
+		expect(parseScope('  mcp:read   mcp:write ')).toEqual(['mcp:read', 'mcp:write']);
+		expect(parseScope('')).toEqual([]);
+		expect(parseScope(null)).toEqual([]);
+		expect(parseScope(undefined)).toEqual([]);
+	});
+});
+
+describe('allScopesSupported', () => {
+	it('accepts known scopes only', () => {
+		expect(allScopesSupported(['mcp:read'])).toBe(true);
+		expect(allScopesSupported(['mcp:read', 'mcp:write'])).toBe(true);
+		expect(allScopesSupported([])).toBe(true);
+		expect(allScopesSupported(['mcp:read', 'admin'])).toBe(false);
+		expect(allScopesSupported(['openid'])).toBe(false);
+	});
+});
+
+describe('isSubsetScope', () => {
+	it('is true only when requested ⊆ granted (no widening on refresh)', () => {
+		expect(isSubsetScope(['mcp:read'], ['mcp:read', 'mcp:write'])).toBe(true);
+		expect(isSubsetScope(['mcp:read', 'mcp:write'], ['mcp:read', 'mcp:write'])).toBe(true);
+		expect(isSubsetScope([], ['mcp:read'])).toBe(true);
+		expect(isSubsetScope(['mcp:write'], ['mcp:read'])).toBe(false);
+		expect(isSubsetScope(['mcp:read', 'mcp:write'], ['mcp:read'])).toBe(false);
+	});
+});
+
+describe('serializeScope', () => {
+	it('joins with spaces', () => {
+		expect(serializeScope(['mcp:read', 'mcp:write'])).toBe('mcp:read mcp:write');
+		expect(serializeScope([])).toBe('');
+	});
+});

--- a/src/lib/server/oauth/scope.ts
+++ b/src/lib/server/oauth/scope.ts
@@ -1,0 +1,28 @@
+/**
+ * Scope parsing/validation — pure. Scopes are space-delimited (RFC 6749 §3.3).
+ */
+import { OAUTH_SCOPES_SUPPORTED, type OAuthScope } from './config';
+
+export function parseScope(raw: string | null | undefined): string[] {
+	if (!raw) return [];
+	return raw.split(/\s+/).filter(Boolean);
+}
+
+export function isSupportedScope(s: string): s is OAuthScope {
+	return (OAUTH_SCOPES_SUPPORTED as readonly string[]).includes(s);
+}
+
+/** True iff every requested scope is one we support. */
+export function allScopesSupported(scopes: string[]): boolean {
+	return scopes.every(isSupportedScope);
+}
+
+/** True iff `requested` ⊆ `granted` — a refresh may narrow but never widen scope. */
+export function isSubsetScope(requested: string[], granted: string[]): boolean {
+	const set = new Set(granted);
+	return requested.every((s) => set.has(s));
+}
+
+export function serializeScope(scopes: string[]): string {
+	return scopes.join(' ');
+}

--- a/src/lib/server/oauth/secret.test.ts
+++ b/src/lib/server/oauth/secret.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test';
+import {
+	generateAuthCode,
+	generateRefreshToken,
+	generateClientId,
+	hashSecret,
+	REFRESH_TOKEN_PREFIX
+} from './secret';
+
+describe('opaque secret generation', () => {
+	it('produces high-entropy, distinct values', () => {
+		const a = generateAuthCode();
+		const b = generateAuthCode();
+		expect(a).not.toBe(b);
+		expect(a.length).toBeGreaterThanOrEqual(43); // 32 bytes base64url
+	});
+
+	it('prefixes refresh tokens', () => {
+		const t = generateRefreshToken();
+		expect(t.startsWith(REFRESH_TOKEN_PREFIX)).toBe(true);
+		expect(t.length).toBeGreaterThan(REFRESH_TOKEN_PREFIX.length + 20);
+	});
+
+	it('client ids are distinct and prefix-free', () => {
+		expect(generateClientId()).not.toBe(generateClientId());
+		expect(generateClientId().startsWith(REFRESH_TOKEN_PREFIX)).toBe(false);
+	});
+});
+
+describe('hashSecret', () => {
+	it('is deterministic and hex sha-256', () => {
+		const h = hashSecret('lemon');
+		expect(h).toBe(hashSecret('lemon'));
+		expect(h).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('differs for different inputs', () => {
+		expect(hashSecret('a')).not.toBe(hashSecret('b'));
+	});
+});

--- a/src/lib/server/oauth/secret.ts
+++ b/src/lib/server/oauth/secret.ts
@@ -1,0 +1,36 @@
+/**
+ * Opaque-secret generation + hashing for the OAuth flow — pure, no env/DB.
+ *
+ * Authorization codes and refresh tokens are random opaque strings; only their
+ * SHA-256 hash is ever stored (same scheme as the PAT store), so a DB read never
+ * yields a usable credential. Client IDs are public, so they are stored as-is.
+ */
+import { sha256 } from '@oslojs/crypto/sha2';
+import { encodeBase64url, encodeHexLowerCase } from '@oslojs/encoding';
+
+/** Refresh tokens carry a recognizable, non-secret prefix (like PATs do). */
+export const REFRESH_TOKEN_PREFIX = 'lemon_rt_';
+
+function randomBase64url(bytes: number): string {
+	return encodeBase64url(crypto.getRandomValues(new Uint8Array(bytes)));
+}
+
+/** A single-use authorization code (opaque, 256 bits). */
+export function generateAuthCode(): string {
+	return randomBase64url(32);
+}
+
+/** A refresh token: prefix + 256 bits of entropy. */
+export function generateRefreshToken(): string {
+	return `${REFRESH_TOKEN_PREFIX}${randomBase64url(32)}`;
+}
+
+/** A public client identifier (128 bits is plenty; it is not a secret). */
+export function generateClientId(): string {
+	return randomBase64url(16);
+}
+
+/** SHA-256 hex digest — what we store and look codes/refresh-tokens up by. */
+export function hashSecret(value: string): string {
+	return encodeHexLowerCase(sha256(new TextEncoder().encode(value)));
+}

--- a/src/lib/server/oauth/store.ts
+++ b/src/lib/server/oauth/store.ts
@@ -1,0 +1,167 @@
+/**
+ * Persistence for the OAuth authorization server: clients, authorization codes,
+ * and refresh tokens. Authorization codes and refresh tokens are SINGLE-USE —
+ * redemption flips `consumedAt` under a `WHERE consumedAt IS NULL AND not expired`
+ * guard via `UPDATE … RETURNING`, so two concurrent requests can never both
+ * spend one credential (no read-then-write race).
+ */
+import { and, eq, gt, isNull } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import type { OAuthClient } from '$lib/server/db/schema';
+import { generateAuthCode, generateClientId, generateRefreshToken, hashSecret } from './secret';
+import { AUTH_CODE_TTL_MS, REFRESH_TOKEN_TTL_SECONDS } from './config';
+
+// ---------------------------------------------------------------- clients ----
+
+export async function registerClient(meta: {
+	redirectUris: string[];
+	clientName: string | null;
+	clientUri: string | null;
+	logoUri: string | null;
+	scope: string | null;
+	softwareId: string | null;
+}): Promise<OAuthClient> {
+	const now = new Date();
+	const row: table.NewOAuthClient = {
+		id: generateClientId(),
+		clientName: meta.clientName,
+		redirectUris: JSON.stringify(meta.redirectUris),
+		grantTypes: JSON.stringify(['authorization_code', 'refresh_token']),
+		responseTypes: JSON.stringify(['code']),
+		tokenEndpointAuthMethod: 'none',
+		scope: meta.scope,
+		clientUri: meta.clientUri,
+		logoUri: meta.logoUri,
+		softwareId: meta.softwareId,
+		createdAt: now
+	};
+	await db.insert(table.oauthClient).values(row);
+	return row as OAuthClient;
+}
+
+export async function getClient(clientId: string): Promise<OAuthClient | null> {
+	const [row] = await db.select().from(table.oauthClient).where(eq(table.oauthClient.id, clientId));
+	return row ?? null;
+}
+
+/** Parse the stored JSON redirect_uris, tolerating corruption (→ empty list). */
+export function clientRedirectUris(client: OAuthClient): string[] {
+	try {
+		const parsed = JSON.parse(client.redirectUris);
+		return Array.isArray(parsed) ? parsed.filter((u): u is string => typeof u === 'string') : [];
+	} catch {
+		return [];
+	}
+}
+
+// ------------------------------------------------------------ auth codes ----
+
+/** Issue an authorization code; returns the plaintext code (only its hash is stored). */
+export async function issueAuthCode(params: {
+	clientId: string;
+	userId: string;
+	redirectUri: string;
+	codeChallenge: string;
+	scope: string;
+	resource: string;
+}): Promise<string> {
+	const code = generateAuthCode();
+	const now = new Date();
+	await db.insert(table.oauthAuthCode).values({
+		id: crypto.randomUUID(),
+		tokenHash: hashSecret(code),
+		clientId: params.clientId,
+		userId: params.userId,
+		redirectUri: params.redirectUri,
+		codeChallenge: params.codeChallenge,
+		codeChallengeMethod: 'S256',
+		scope: params.scope,
+		resource: params.resource,
+		expiresAt: new Date(now.getTime() + AUTH_CODE_TTL_MS),
+		createdAt: now
+	});
+	return code;
+}
+
+/**
+ * Atomically claim an authorization code. Returns the row only if it existed,
+ * was unconsumed, and was unexpired — otherwise null. The claim is the write
+ * itself, so replay/double-spend is impossible.
+ */
+export async function consumeAuthCode(code: string): Promise<table.OAuthAuthCode | null> {
+	const now = new Date();
+	const [row] = await db
+		.update(table.oauthAuthCode)
+		.set({ consumedAt: now })
+		.where(
+			and(
+				eq(table.oauthAuthCode.tokenHash, hashSecret(code)),
+				isNull(table.oauthAuthCode.consumedAt),
+				gt(table.oauthAuthCode.expiresAt, now)
+			)
+		)
+		.returning();
+	return row ?? null;
+}
+
+// --------------------------------------------------------- refresh tokens ----
+
+/** Issue a refresh token; returns the plaintext token (only its hash is stored). */
+export async function issueRefreshToken(params: {
+	clientId: string;
+	userId: string;
+	scope: string;
+	resource: string;
+}): Promise<string> {
+	const token = generateRefreshToken();
+	const now = new Date();
+	await db.insert(table.oauthRefreshToken).values({
+		id: crypto.randomUUID(),
+		tokenHash: hashSecret(token),
+		clientId: params.clientId,
+		userId: params.userId,
+		scope: params.scope,
+		resource: params.resource,
+		expiresAt: new Date(now.getTime() + REFRESH_TOKEN_TTL_SECONDS * 1000),
+		createdAt: now
+	});
+	return token;
+}
+
+/**
+ * Atomically claim (rotate) a refresh token. Returns the row only if valid,
+ * unconsumed, and unexpired. Caller issues a replacement.
+ */
+export async function consumeRefreshToken(token: string): Promise<table.OAuthRefreshToken | null> {
+	const now = new Date();
+	const [row] = await db
+		.update(table.oauthRefreshToken)
+		.set({ consumedAt: now })
+		.where(
+			and(
+				eq(table.oauthRefreshToken.tokenHash, hashSecret(token)),
+				isNull(table.oauthRefreshToken.consumedAt),
+				gt(table.oauthRefreshToken.expiresAt, now)
+			)
+		)
+		.returning();
+	return row ?? null;
+}
+
+/** Revoke every outstanding refresh token for a (client,user) — used on code replay. */
+export async function revokeRefreshTokensForUserClient(
+	userId: string,
+	clientId: string
+): Promise<void> {
+	await db
+		.update(table.oauthRefreshToken)
+		.set({ consumedAt: new Date() })
+		.where(
+			and(
+				eq(table.oauthRefreshToken.userId, userId),
+				eq(table.oauthRefreshToken.clientId, clientId),
+				isNull(table.oauthRefreshToken.consumedAt)
+			)
+		);
+}

--- a/src/routes/(user)/login/+page.server.ts
+++ b/src/routes/(user)/login/+page.server.ts
@@ -5,22 +5,21 @@ import * as auth from '$lib/server/auth';
 import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { LOGIN_SCHEMA, REGISTER_SCHEMA } from '$lib/validations/auth';
+import { safeInternalPath } from '$lib/server/oauth/redirect';
 import { dev } from '$app/environment';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
 	if (event.locals.user) {
 		console.info('[Login] User already authenticated, redirecting to intended destination');
-		const redirectTo = event.url.searchParams.get('redirect') || '/';
-
-		// If there's a redirect parameter, use it directly (it should contain the full URL)
-		// Otherwise, redirect to home
-		const targetUrl = redirectTo || '/';
-		return redirect(302, targetUrl);
+		// Only ever redirect to a same-origin path — never an attacker-supplied
+		// absolute URL (open redirect). This gate is what makes it safe to route
+		// the OAuth flow through `/login?redirect=/oauth/authorize?…`.
+		return redirect(302, safeInternalPath(event.url.searchParams.get('redirect')));
 	}
 
 	return {
-		redirect: event.url.searchParams.get('redirect') || '/',
+		redirect: safeInternalPath(event.url.searchParams.get('redirect')),
 		tab: event.url.searchParams.get('tab') === 'register' ? 'register' : 'login',
 		message: event.url.searchParams.get('message')
 	};
@@ -75,8 +74,8 @@ export const actions: Actions = {
 			`[Login] Successfully logged in user: ${result.data.username} with ${sessionType} session`
 		);
 
-		// Return success with redirect information
-		const redirectTo = event.url.searchParams.get('redirect') || '/';
+		// Return success with redirect information (same-origin only — open-redirect guard)
+		const redirectTo = safeInternalPath(event.url.searchParams.get('redirect'));
 		return { success: true, redirect: redirectTo };
 	},
 	register: async (event) => {
@@ -151,8 +150,8 @@ export const actions: Actions = {
 			console.info('[Register] ====== Registration complete ======');
 		}
 
-		// Return success with redirect information
-		const redirectTo = event.url.searchParams.get('redirect') || '/';
+		// Return success with redirect information (same-origin only — open-redirect guard)
+		const redirectTo = safeInternalPath(event.url.searchParams.get('redirect'));
 		return { success: true, redirect: redirectTo };
 	}
 };

--- a/src/routes/oauth/authorize/+page.server.ts
+++ b/src/routes/oauth/authorize/+page.server.ts
@@ -1,0 +1,168 @@
+/**
+ * OAuth /authorize — the browser-facing consent step (RFC 6749 §4.1.1 + PKCE).
+ *
+ * load() validates the request, requires a logged-in session (bouncing through
+ * /login?redirect=… otherwise), and renders consent. The approve/deny actions
+ * RE-VALIDATE every parameter against the registered client (hidden fields are
+ * untrusted) before issuing a code or redirecting — so tampering the form can
+ * never widen scope, change audience, or redirect a code to an attacker.
+ */
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+import { dev } from '$app/environment';
+import {
+	checkAuthorizeParams,
+	buildRedirect,
+	type AuthorizeParams
+} from '$lib/server/oauth/authorize-core';
+import { getClient, clientRedirectUris, issueAuthCode } from '$lib/server/oauth/store';
+import { safeInternalPath } from '$lib/server/oauth/redirect';
+
+const CSRF_COOKIE = 'oauth_consent_csrf';
+
+function paramsFromSearch(searchParams: URLSearchParams): AuthorizeParams {
+	return {
+		responseType: searchParams.get('response_type'),
+		clientId: searchParams.get('client_id'),
+		redirectUri: searchParams.get('redirect_uri'),
+		codeChallenge: searchParams.get('code_challenge'),
+		codeChallengeMethod: searchParams.get('code_challenge_method'),
+		scope: searchParams.get('scope'),
+		state: searchParams.get('state'),
+		resource: searchParams.get('resource')
+	};
+}
+
+async function resolveCheck(params: AuthorizeParams) {
+	const client = params.clientId ? await getClient(params.clientId) : null;
+	const registered = client ? clientRedirectUris(client) : [];
+	return { client, check: checkAuthorizeParams(params, registered) };
+}
+
+export const load: PageServerLoad = async ({ url, locals, cookies }) => {
+	const params = paramsFromSearch(url.searchParams);
+	const { client, check } = await resolveCheck(params);
+
+	if (check.status === 'invalid') {
+		return { ok: false as const, message: check.description };
+	}
+	if (check.status === 'redirect_error') {
+		throw redirect(
+			302,
+			buildRedirect(check.redirectUri, {
+				error: check.error,
+				error_description: check.description,
+				state: check.state
+			})
+		);
+	}
+
+	// Valid request — now require a logged-in user.
+	if (!locals.user) {
+		const back = safeInternalPath(url.pathname + url.search, '/');
+		throw redirect(302, `/login?redirect=${encodeURIComponent(back)}`);
+	}
+
+	// Double-submit CSRF token for the consent POST.
+	const csrf = crypto.randomUUID();
+	cookies.set(CSRF_COOKIE, csrf, {
+		path: '/oauth',
+		httpOnly: true,
+		secure: !dev,
+		sameSite: 'lax',
+		maxAge: 600
+	});
+
+	return {
+		ok: true as const,
+		csrf,
+		username: locals.user.username,
+		clientName: client?.clientName ?? null,
+		clientId: params.clientId,
+		clientUri: client?.clientUri ?? null,
+		scopes: check.scopes,
+		// Echoed back as hidden fields; the actions re-validate them, so they are
+		// not trusted — they exist only to survive the POST round-trip.
+		fields: {
+			response_type: 'code',
+			client_id: params.clientId ?? '',
+			redirect_uri: check.redirectUri,
+			code_challenge: check.codeChallenge,
+			code_challenge_method: 'S256',
+			scope: check.scope,
+			state: check.state ?? '',
+			resource: check.resource
+		}
+	};
+};
+
+function paramsFromForm(form: FormData): AuthorizeParams {
+	const s = (k: string) => {
+		const v = form.get(k);
+		return typeof v === 'string' && v.length > 0 ? v : null;
+	};
+	return {
+		responseType: s('response_type'),
+		clientId: s('client_id'),
+		redirectUri: s('redirect_uri'),
+		codeChallenge: s('code_challenge'),
+		codeChallengeMethod: s('code_challenge_method'),
+		scope: s('scope'),
+		state: s('state'),
+		resource: s('resource')
+	};
+}
+
+function checkCsrf(form: FormData, cookies: import('@sveltejs/kit').Cookies): boolean {
+	const cookie = cookies.get(CSRF_COOKIE);
+	const field = form.get('csrf');
+	return !!cookie && typeof field === 'string' && field === cookie;
+}
+
+export const actions: Actions = {
+	approve: async ({ request, locals, cookies }) => {
+		const form = await request.formData();
+		if (!locals.user)
+			return { ok: false as const, message: 'Your session expired. Please sign in again.' };
+		if (!checkCsrf(form, cookies))
+			return { ok: false as const, message: 'Invalid request (CSRF). Please retry.' };
+
+		const params = paramsFromForm(form);
+		const { check } = await resolveCheck(params);
+		if (check.status === 'invalid') return { ok: false as const, message: check.description };
+		if (check.status === 'redirect_error') {
+			throw redirect(
+				302,
+				buildRedirect(check.redirectUri, {
+					error: check.error,
+					error_description: check.description,
+					state: check.state
+				})
+			);
+		}
+
+		const code = await issueAuthCode({
+			clientId: params.clientId!,
+			userId: locals.user.id,
+			redirectUri: check.redirectUri,
+			codeChallenge: check.codeChallenge,
+			scope: check.scope,
+			resource: check.resource
+		});
+		cookies.delete(CSRF_COOKIE, { path: '/oauth' });
+		throw redirect(302, buildRedirect(check.redirectUri, { code, state: check.state }));
+	},
+
+	deny: async ({ request, cookies }) => {
+		const form = await request.formData();
+		const params = paramsFromForm(form);
+		const { check } = await resolveCheck(params);
+		cookies.delete(CSRF_COOKIE, { path: '/oauth' });
+		// Only redirect to a re-validated redirect_uri; otherwise show the error page.
+		if (check.status === 'invalid') return { ok: false as const, message: 'Authorization denied.' };
+		throw redirect(
+			302,
+			buildRedirect(check.redirectUri, { error: 'access_denied', state: check.state })
+		);
+	}
+};

--- a/src/routes/oauth/authorize/+page.svelte
+++ b/src/routes/oauth/authorize/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages';
+	import ShieldCheck from '~icons/lucide/shield-check';
+	import KeyRound from '~icons/lucide/key-round';
+	import Eye from '~icons/lucide/eye';
+	import Pencil from '~icons/lucide/pencil';
+	import type { PageServerData } from './$types';
+
+	type FormResult = { ok: false; message: string } | null;
+	let { data, form }: { data: PageServerData; form: FormResult } = $props();
+
+	const scopeMeta: Record<string, { label: () => string; icon: typeof Eye }> = {
+		'mcp:read': { label: () => m.oauth_scope_read(), icon: Eye },
+		'mcp:write': { label: () => m.oauth_scope_write(), icon: Pencil }
+	};
+</script>
+
+<svelte:head>
+	<title>{m.oauth_authorize_title()} — LemonTV</title>
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="flex min-h-[70vh] items-center justify-center px-4 py-10">
+	<div class="w-full max-w-md rounded-2xl border border-zinc-700 bg-zinc-900 p-8 shadow-xl">
+		{#if !data.ok || form?.ok === false}
+			<div class="flex flex-col items-center text-center">
+				<KeyRound class="mb-3 h-10 w-10 text-red-400" />
+				<h1 class="mb-2 text-xl font-bold text-white">{m.oauth_authorize_error_title()}</h1>
+				<p class="text-sm text-zinc-400">
+					{form?.ok === false ? form.message : !data.ok ? data.message : ''}
+				</p>
+				<a href="/" class="mt-6 text-sm text-yellow-400 hover:underline">LemonTV</a>
+			</div>
+		{:else}
+			<div class="mb-6 flex flex-col items-center text-center">
+				<ShieldCheck class="mb-3 h-10 w-10 text-yellow-400" />
+				<h1 class="text-xl font-bold text-white">{m.oauth_authorize_title()}</h1>
+				<p class="mt-2 text-sm text-zinc-300">
+					{m.oauth_authorize_app_wants({
+						app: data.clientName ?? m.oauth_authorize_unknown_app()
+					})}
+				</p>
+				{#if data.clientUri}
+					<a
+						href={data.clientUri}
+						class="mt-1 text-xs text-zinc-500 hover:underline"
+						target="_blank"
+						rel="noopener noreferrer">{data.clientUri}</a
+					>
+				{/if}
+			</div>
+
+			<p class="mb-2 text-xs font-semibold tracking-wide text-zinc-400 uppercase">
+				{m.oauth_authorize_permissions()}
+			</p>
+			<ul class="mb-6 space-y-2">
+				{#each data.scopes as scope (scope)}
+					{@const meta = scopeMeta[scope]}
+					<li class="flex items-start gap-3 rounded-lg bg-zinc-800/60 px-3 py-2">
+						{#if meta}
+							<meta.icon class="mt-0.5 h-4 w-4 shrink-0 text-yellow-400" />
+							<span class="text-sm text-zinc-200">{meta.label()}</span>
+						{:else}
+							<span class="text-sm text-zinc-200">{scope}</span>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+
+			<p class="mb-4 text-center text-xs text-zinc-500">{m.oauth_authorize_review_note()}</p>
+
+			<form method="POST" class="flex flex-col gap-3">
+				<input type="hidden" name="csrf" value={data.csrf} />
+				{#each Object.entries(data.fields) as [name, value] (name)}
+					<input type="hidden" {name} {value} />
+				{/each}
+
+				<div class="flex gap-3">
+					<button
+						type="submit"
+						formaction="?/deny"
+						class="flex-1 rounded-lg border border-zinc-600 px-4 py-2.5 text-sm font-semibold text-zinc-300 transition hover:bg-zinc-800"
+					>
+						{m.oauth_deny_button()}
+					</button>
+					<button
+						type="submit"
+						formaction="?/approve"
+						class="flex-1 rounded-lg bg-yellow-400 px-4 py-2.5 text-sm font-bold text-zinc-900 transition hover:bg-yellow-300"
+					>
+						{m.oauth_authorize_button()}
+					</button>
+				</div>
+			</form>
+
+			<p class="mt-5 text-center text-xs text-zinc-500">
+				{m.oauth_authorize_signed_in_as({ username: data.username })}
+			</p>
+		{/if}
+	</div>
+</div>

--- a/src/routes/oauth/register/+server.ts
+++ b/src/routes/oauth/register/+server.ts
@@ -1,0 +1,48 @@
+/**
+ * Dynamic Client Registration (RFC 7591). Public, unauthenticated — MCP clients
+ * self-register to obtain a client_id before starting the PKCE flow. Accepts a
+ * JSON body; there is no client secret (public clients only). CSRF-exempt in
+ * hooks because it carries no ambient credentials (nothing for CSRF to abuse).
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { validateDcrRequest, type DcrRequestBody } from '$lib/server/oauth/dcr-core';
+import { registerClient } from '$lib/server/oauth/store';
+
+export const POST: RequestHandler = async ({ request }) => {
+	let body: DcrRequestBody;
+	try {
+		body = (await request.json()) as DcrRequestBody;
+	} catch {
+		return json(
+			{ error: 'invalid_client_metadata', error_description: 'body must be JSON' },
+			{ status: 400, headers: { 'Cache-Control': 'no-store' } }
+		);
+	}
+
+	const result = validateDcrRequest(body);
+	if (!result.ok) {
+		return json(
+			{ error: result.error, error_description: result.description },
+			{ status: 400, headers: { 'Cache-Control': 'no-store' } }
+		);
+	}
+
+	const client = await registerClient(result.value);
+
+	return json(
+		{
+			client_id: client.id,
+			client_id_issued_at: Math.floor(client.createdAt.getTime() / 1000),
+			token_endpoint_auth_method: 'none',
+			grant_types: ['authorization_code', 'refresh_token'],
+			response_types: ['code'],
+			redirect_uris: result.value.redirectUris,
+			client_name: client.clientName ?? undefined,
+			client_uri: client.clientUri ?? undefined,
+			logo_uri: client.logoUri ?? undefined,
+			scope: client.scope ?? undefined
+		},
+		{ status: 201, headers: { 'Cache-Control': 'no-store' } }
+	);
+};

--- a/src/routes/oauth/token/+server.ts
+++ b/src/routes/oauth/token/+server.ts
@@ -1,0 +1,172 @@
+/**
+ * OAuth token endpoint (RFC 6749 §4.1.3 / §6, OAuth 2.1). Accepts
+ * `application/x-www-form-urlencoded` from public PKCE clients — CSRF-exempt in
+ * hooks because security here comes from the code + PKCE verifier (or the
+ * refresh token), never from an ambient cookie.
+ *
+ * Both authorization codes and refresh tokens are single-use; detecting reuse of
+ * either triggers revocation of that (user,client)'s refresh tokens — the
+ * OAuth 2.1 replay-detection defense against a leaked code/token.
+ */
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { verifyPkceS256 } from '$lib/server/oauth/pkce';
+import { hashSecret } from '$lib/server/oauth/secret';
+import { parseScope, isSubsetScope, serializeScope } from '$lib/server/oauth/scope';
+import { mintAccessToken } from '$lib/server/oauth/token';
+import {
+	consumeAuthCode,
+	consumeRefreshToken,
+	issueRefreshToken,
+	revokeRefreshTokensForUserClient
+} from '$lib/server/oauth/store';
+import { ACCESS_TOKEN_TTL_SECONDS, MCP_RESOURCE } from '$lib/server/oauth/config';
+
+const NO_STORE = { 'Cache-Control': 'no-store', Pragma: 'no-cache' };
+
+function oauthError(error: string, description: string, status = 400) {
+	return json({ error, error_description: description }, { status, headers: NO_STORE });
+}
+
+interface TokenSuccess {
+	userId: string;
+	clientId: string;
+	scope: string;
+	resource: string;
+}
+
+async function success({ userId, clientId, scope, resource }: TokenSuccess) {
+	const access_token = await mintAccessToken({ sub: userId, scope, clientId });
+	const refresh_token = await issueRefreshToken({ userId, clientId, scope, resource });
+	return json(
+		{
+			access_token,
+			token_type: 'Bearer',
+			expires_in: ACCESS_TOKEN_TTL_SECONDS,
+			scope,
+			refresh_token
+		},
+		{ headers: NO_STORE }
+	);
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	let form: FormData;
+	try {
+		form = await request.formData();
+	} catch {
+		return oauthError('invalid_request', 'body must be application/x-www-form-urlencoded');
+	}
+	const get = (k: string) => {
+		const v = form.get(k);
+		return typeof v === 'string' ? v : null;
+	};
+
+	const grantType = get('grant_type');
+
+	// ------------------------------------------------ authorization_code ----
+	if (grantType === 'authorization_code') {
+		const code = get('code');
+		const clientId = get('client_id');
+		const redirectUri = get('redirect_uri');
+		const codeVerifier = get('code_verifier');
+		const resource = get('resource');
+
+		if (!code || !clientId || !redirectUri || !codeVerifier) {
+			return oauthError(
+				'invalid_request',
+				'missing code, client_id, redirect_uri, or code_verifier'
+			);
+		}
+
+		const row = await consumeAuthCode(code);
+		if (!row) {
+			// Either never existed, expired, or a REPLAY of an already-spent code.
+			// On replay, revoke any tokens already issued from it (OAuth 2.1).
+			const [spent] = await db
+				.select({ userId: table.oauthAuthCode.userId, clientId: table.oauthAuthCode.clientId })
+				.from(table.oauthAuthCode)
+				.where(eq(table.oauthAuthCode.tokenHash, hashSecret(code)));
+			if (spent) await revokeRefreshTokensForUserClient(spent.userId, spent.clientId);
+			return oauthError('invalid_grant', 'authorization code is invalid, expired, or already used');
+		}
+
+		if (row.clientId !== clientId) {
+			return oauthError('invalid_grant', 'client_id does not match the authorization code');
+		}
+		if (row.redirectUri !== redirectUri) {
+			return oauthError('invalid_grant', 'redirect_uri does not match the authorization request');
+		}
+		if (!verifyPkceS256(codeVerifier, row.codeChallenge)) {
+			return oauthError('invalid_grant', 'PKCE verification failed');
+		}
+		if (resource && resource !== row.resource) {
+			return oauthError('invalid_target', 'resource does not match the authorization request');
+		}
+
+		return success({
+			userId: row.userId,
+			clientId: row.clientId,
+			scope: row.scope,
+			resource: row.resource
+		});
+	}
+
+	// ------------------------------------------------------ refresh_token ----
+	if (grantType === 'refresh_token') {
+		const refreshToken = get('refresh_token');
+		const clientId = get('client_id');
+		const requestedScope = get('scope');
+		const resource = get('resource');
+
+		if (!refreshToken || !clientId) {
+			return oauthError('invalid_request', 'missing refresh_token or client_id');
+		}
+
+		const row = await consumeRefreshToken(refreshToken);
+		if (!row) {
+			// Reuse of a rotated/expired refresh token → revoke the whole chain.
+			const [spent] = await db
+				.select({
+					userId: table.oauthRefreshToken.userId,
+					clientId: table.oauthRefreshToken.clientId
+				})
+				.from(table.oauthRefreshToken)
+				.where(eq(table.oauthRefreshToken.tokenHash, hashSecret(refreshToken)));
+			if (spent) await revokeRefreshTokensForUserClient(spent.userId, spent.clientId);
+			return oauthError('invalid_grant', 'refresh token is invalid, expired, or already used');
+		}
+
+		if (row.clientId !== clientId) {
+			return oauthError('invalid_grant', 'client_id does not match the refresh token');
+		}
+		if (resource && resource !== row.resource) {
+			return oauthError('invalid_target', 'resource does not match the refresh token');
+		}
+
+		// A refresh may narrow scope but never widen it.
+		let scope = row.scope;
+		const requested = parseScope(requestedScope);
+		if (requested.length > 0) {
+			if (!isSubsetScope(requested, parseScope(row.scope))) {
+				return oauthError('invalid_scope', 'requested scope exceeds the granted scope');
+			}
+			scope = serializeScope(requested);
+		}
+
+		return success({
+			userId: row.userId,
+			clientId: row.clientId,
+			scope,
+			resource: row.resource || MCP_RESOURCE
+		});
+	}
+
+	return oauthError(
+		'unsupported_grant_type',
+		'grant_type must be authorization_code or refresh_token'
+	);
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,7 +3,16 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
 	preprocess: vitePreprocess(),
-	kit: { adapter: adapter(), alias: { $assets: './src/assets' } }
+	kit: {
+		adapter: adapter(),
+		alias: { $assets: './src/assets' },
+		// The built-in origin check rejects ALL cross-origin form-encoded POSTs,
+		// which would break the OAuth token/register endpoints (public clients POST
+		// `application/x-www-form-urlencoded` cross-origin). We disable it here and
+		// re-implement the exact same check in hooks.server.ts (`handleCsrf`),
+		// carving out only those two OAuth machine endpoints. See that hook.
+		csrf: { checkOrigin: false }
+	}
 };
 
 export default config;


### PR DESCRIPTION
**Stacked on #58 (PR A)** — review/merge that first; this targets the PR A branch so the diff is just PR B. Together they make MCP OAuth login work end-to-end: an MCP client (Claude Code / Desktop) connects and the user **logs into LemonTV in the browser** instead of pasting a PAT.

## Endpoints (`/oauth`)
- **POST `/oauth/register`** — Dynamic Client Registration (RFC 7591). Public clients only (`token_endpoint_auth_method=none`, no secret); strict redirect-URI validation (https or loopback http, no fragment).
- **GET `/oauth/authorize`** — consent screen (RFC 6749 §4.1.1 + PKCE). Bounces to `/login?redirect=…` when signed out, then renders consent showing the app + requested scopes. Approve/Deny **re-validate every parameter** against the registered client (hidden fields are untrusted), with a double-submit CSRF token.
- **POST `/oauth/token`** — `authorization_code` + `refresh_token` grants (form-encoded). PKCE S256 verified; codes & refresh tokens are **single-use** (atomic `UPDATE…RETURNING` claim). Reuse of either **revokes** that (user,client)'s refresh tokens (OAuth 2.1 replay detection). Refresh may narrow scope, never widen.

## Security controls
- **Redirect-URI gate** — unknown client or non-exact redirect_uri → a *non-redirecting* error page (never leak a code to an attacker URI); only post-gate errors redirect back.
- **Least privilege at the resource server** — `identity.ts` now **rejects a token lacking `mcp:read`** (write implies read). Fixes a review finding where a scope-less token still got read access via the dispatcher.
- **Open-redirect hardening** — login `?redirect=` is now **same-origin-path only** (`safeInternalPath`) — the gate that makes routing OAuth through `/login` safe.
- **CSRF** — SvelteKit's global origin check (which blocks the cross-origin form posts OAuth public clients must make) is disabled and **re-implemented in `hooks.server.ts`** with a carve-out for **only** `/oauth/token` + `/oauth/register` (no ambient cookie creds there). Every other route keeps identical protection.
- **Audience binding** (from PR A) — every issued token has `aud = https://lemontv.win/api/mcp`; the legacy SSO token (different aud) can't be replayed at the MCP endpoint.

## Schema / keys
`oauth_refresh_token` (single-use, rotated, hash-only) + migration `0004` (1 table, **0 rebuilds**). Reuses the existing ES256 key — **no new secrets**.

## Tested
`bun test src/` → **174 pass** (37 new: DCR validation, authorize gate, scope subset/widening, safe-redirect, secret hashing). `bun run check` → 0 errors in the OAuth code.

## Notes
- OAuth requests still skip audit/rate-limit (the PAT-keyed tables need generalizing) — follow-up.
- `csrf.checkOrigin:false` shows a deprecation warning in 2.49.x but still functions; `trustedOrigins` can't express "accept arbitrary-origin posts to two endpoints," so the hook approach stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)