### PR TITLE
feat(mcp): add update_event tool for refining events

### DIFF
--- a/src/lib/server/data/events.ts
+++ b/src/lib/server/data/events.ts
@@ -284,6 +284,111 @@ export async function createEvent(
 	return { id };
 }
 
+/** Scalar event fields an MCP/editor partial-update may change (no related tables). */
+export interface UpdateEventFields {
+	name?: string;
+	slug?: string;
+	server?: string;
+	format?: string;
+	region?: string;
+	status?: string;
+	date?: string;
+	image?: string;
+	official?: boolean;
+	capacity?: number;
+}
+
+/**
+ * Update an existing event's scalar fields, located by id OR slug. Only the
+ * fields provided are changed; enum fields are validated and a slug change is
+ * checked for uniqueness. One `edit_history` row is written per changed field
+ * (attributed to `editedBy`), mirroring the admin edit path.
+ */
+export async function updateEvent(
+	idOrSlug: string,
+	fields: UpdateEventFields,
+	editedBy: string,
+	options: { source?: string } = {}
+): Promise<{ id: string; changed: string[] }> {
+	const [existing] = await db
+		.select()
+		.from(table.event)
+		.where(or(eq(table.event.id, idOrSlug), eq(table.event.slug, idOrSlug)))
+		.limit(1);
+	if (!existing) {
+		throw new Error(`No event found with id or slug "${idOrSlug}"`);
+	}
+
+	if (fields.server !== undefined && !EVENT_SERVERS.includes(fields.server as never)) {
+		throw new Error(
+			`Invalid server "${fields.server}" (expected one of: ${EVENT_SERVERS.join(', ')})`
+		);
+	}
+	if (fields.format !== undefined && !EVENT_FORMATS.includes(fields.format as never)) {
+		throw new Error(
+			`Invalid format "${fields.format}" (expected one of: ${EVENT_FORMATS.join(', ')})`
+		);
+	}
+	if (fields.status !== undefined && !EVENT_STATUSES.includes(fields.status as never)) {
+		throw new Error(
+			`Invalid status "${fields.status}" (expected one of: ${EVENT_STATUSES.join(', ')})`
+		);
+	}
+
+	if (fields.slug !== undefined && fields.slug !== existing.slug) {
+		const [dupe] = await db
+			.select({ id: table.event.id })
+			.from(table.event)
+			.where(eq(table.event.slug, fields.slug))
+			.limit(1);
+		if (dupe) throw new Error(`An event with slug "${fields.slug}" already exists`);
+	}
+
+	const columns = [
+		'name',
+		'slug',
+		'server',
+		'format',
+		'region',
+		'status',
+		'date',
+		'image',
+		'official',
+		'capacity'
+	] as const;
+
+	const updates: Record<string, unknown> = {};
+	const changed: string[] = [];
+	for (const key of columns) {
+		const next = fields[key];
+		if (next !== undefined && next !== (existing as Record<string, unknown>)[key]) {
+			updates[key] = next;
+			changed.push(key);
+		}
+	}
+
+	if (changed.length === 0) return { id: existing.id, changed: [] };
+
+	await db.transaction(async (tx) => {
+		await tx.update(table.event).set(updates).where(eq(table.event.id, existing.id));
+		for (const field of changed) {
+			const oldValue = (existing as Record<string, unknown>)[field];
+			await tx.insert(table.editHistory).values({
+				id: randomUUID(),
+				tableName: 'event',
+				recordId: existing.id,
+				fieldName: options.source ? `${field} (${options.source})` : field,
+				oldValue: oldValue === null || oldValue === undefined ? null : String(oldValue),
+				newValue: String(updates[field]),
+				editedBy,
+				editedAt: new Date()
+			});
+		}
+	});
+
+	return { id: existing.id, changed };
+}
+
 // Get changes between old and new event data
 export function getEventChanges(
 	oldEvent: Event,

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -9,7 +9,14 @@ import { desc, eq, or } from 'drizzle-orm';
 import type { TCountryCode } from 'countries-list';
 import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
-import { createEvent, EVENT_FORMATS, EVENT_SERVERS, EVENT_STATUSES } from '$lib/server/data/events';
+import {
+	createEvent,
+	updateEvent,
+	EVENT_FORMATS,
+	EVENT_SERVERS,
+	EVENT_STATUSES,
+	type UpdateEventFields
+} from '$lib/server/data/events';
 import { createPlayer, getPlayer, getPlayers } from '$lib/server/data/players';
 import { createTeam, getTeam, getTeams } from '$lib/server/data/teams';
 import { getGameAccountServer } from '$lib/data/players';
@@ -169,6 +176,58 @@ export const TOOLS: McpTool[] = [
 				{ source: 'mcp:create_event' }
 			);
 			return { id, slug, created: true };
+		}
+	},
+	{
+		name: 'update_event',
+		description:
+			'Update fields of an existing LemonTV event, located by id or slug. Only the fields you pass are changed (partial update); useful for filling in dates, region, status, capacity, etc. Returns the id and which fields changed. Edits are attributed to the token owner and recorded in edit history.',
+		requiresWrite: true,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				idOrSlug: { type: 'string', description: 'The event id or slug to update.' },
+				name: { type: 'string', description: 'New display name.' },
+				slug: { type: 'string', description: 'New URL slug (lowercase-kebab, unique).' },
+				server: { type: 'string', enum: [...EVENT_SERVERS], description: 'Game server.' },
+				format: { type: 'string', enum: [...EVENT_FORMATS], description: 'Competition format.' },
+				region: {
+					type: 'string',
+					description: 'Region, e.g. "Global", "NA", "EU", "APAC", "CN", "SA".'
+				},
+				status: { type: 'string', enum: [...EVENT_STATUSES], description: 'Event status.' },
+				date: { type: 'string', description: 'YYYY-MM-DD or a range YYYY-MM-DD/YYYY-MM-DD.' },
+				image: { type: 'string', description: 'Banner/logo URL.' },
+				official: { type: 'boolean', description: 'Whether it is an official event.' },
+				capacity: { type: 'integer', minimum: 0, description: 'Team capacity.' }
+			},
+			required: ['idOrSlug'],
+			additionalProperties: false
+		},
+		handler: async (args, identity) => {
+			const idOrSlug = requireString(args, 'idOrSlug');
+
+			// Build a partial update from only the fields actually supplied, with
+			// per-field type/enum validation (the data layer trusts what it gets).
+			const fields: UpdateEventFields = {};
+			if (args.name !== undefined) fields.name = requireString(args, 'name');
+			if (args.slug !== undefined) fields.slug = formatSlug(requireString(args, 'slug'));
+			if (args.server !== undefined)
+				fields.server = requireEnum(args.server, EVENT_SERVERS, 'server');
+			if (args.format !== undefined)
+				fields.format = requireEnum(args.format, EVENT_FORMATS, 'format');
+			if (args.region !== undefined) fields.region = requireString(args, 'region');
+			if (args.status !== undefined)
+				fields.status = requireEnum(args.status, EVENT_STATUSES, 'status');
+			if (args.date !== undefined) fields.date = requireString(args, 'date');
+			if (args.image !== undefined) fields.image = requireString(args, 'image');
+			if (args.official !== undefined) fields.official = Boolean(args.official);
+			if (args.capacity !== undefined) fields.capacity = requireInt(args, 'capacity');
+
+			const { id, changed } = await updateEvent(idOrSlug, fields, identity.userId, {
+				source: 'mcp:update_event'
+			});
+			return { id, changed, updated: changed.length > 0 };
 		}
 	},
 	{


### PR DESCRIPTION
`create_event` could add events but not correct them — so refining a tournament's details (dates, region, status, capacity once verified) meant going through the admin UI. This adds an MCP-native edit path.

- **data layer** `updateEvent(idOrSlug, fields, editedBy, {source})` — partial scalar update located by **id or slug**, validates enum fields + slug uniqueness, writes **one `edit_history` row per changed field** (same attribution as the admin path).
- **MCP tool** `update_event` (`requiresWrite`) exposing the scalar fields; only the fields you pass are changed.

Motivated by backfilling the new tournament events (空镜杯 #4 / Origami Cup 4 / EmikoAi Nya Nya Cup) with verified data found via research, without re-creating them.

`bun test src/lib/server/mcp` → 42 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)