### PR TITLE
feat(admin): inline status quick-edit on events list

### DIFF
--- a/src/routes/(user)/admin/events/+page.server.ts
+++ b/src/routes/(user)/admin/events/+page.server.ts
@@ -15,6 +15,7 @@ import {
 	toDatabaseEventVideos,
 	getEventChanges,
 	getEventsForAdminPage,
+	updateEvent,
 	updateEventTeamPlayers,
 	updateEventCasters
 } from '$lib/server/data/events';
@@ -683,6 +684,29 @@ export const actions = {
 			return fail(500, {
 				error: 'Failed to delete event'
 			});
+		}
+	},
+
+	// Quick inline status change from the events list (no full edit form).
+	updateStatus: async ({ request, locals }: { request: Request; locals: App.Locals }) => {
+		const result = checkPermissions(locals, ['admin', 'editor']);
+		if (result.status === 'error') {
+			return fail(result.statusCode, { error: result.error });
+		}
+
+		const formData = await request.formData();
+		const id = formData.get('id') as string;
+		const status = formData.get('status') as string;
+		if (!id || !status) {
+			return fail(400, { error: 'Event id and status are required' });
+		}
+
+		try {
+			await updateEvent(id, { status }, result.userId, { source: 'admin:status-quickedit' });
+			return { type: 'success' as const, data: { id, status } };
+		} catch (e) {
+			console.error('[Admin][Events][Status] Failed to update status:', e);
+			return fail(400, { error: e instanceof Error ? e.message : 'Failed to update status' });
 		}
 	},
 

--- a/src/routes/(user)/admin/events/+page.svelte
+++ b/src/routes/(user)/admin/events/+page.svelte
@@ -25,6 +25,23 @@
 
 	$inspect('[admin/events] data', data);
 
+	// Inline status quick-edit on the list (auto-submits ?/updateStatus).
+	const statusOptions = ['upcoming', 'live', 'finished', 'cancelled', 'postponed'];
+	function statusBadgeClass(status: string): string {
+		switch (status) {
+			case 'live':
+				return 'bg-green-900/50 text-green-200';
+			case 'upcoming':
+				return 'bg-blue-900/50 text-blue-200';
+			case 'cancelled':
+				return 'bg-red-900/50 text-red-200';
+			case 'postponed':
+				return 'bg-yellow-900/50 text-yellow-200';
+			default:
+				return 'bg-gray-900/50 text-gray-200';
+		}
+	}
+
 	let selectedEvent: EventWithOrganizers | null = $state(null);
 	let searchQuery = $state(data.searchQuery || '');
 	let sortBy:
@@ -423,20 +440,24 @@
 						<td class="min-w-max px-4 py-1 whitespace-nowrap text-gray-300">{event.format}</td>
 						<td class="min-w-max px-4 py-1 whitespace-nowrap text-gray-300">{event.region}</td>
 						<td class="min-w-max px-4 py-1 whitespace-nowrap">
-							<span
-								class="inline-flex rounded-full px-2 text-xs leading-5 font-semibold {event.status ===
-								'live'
-									? 'bg-green-900/50 text-green-200'
-									: event.status === 'upcoming'
-										? 'bg-blue-900/50 text-blue-200'
-										: event.status === 'cancelled'
-											? 'bg-red-900/50 text-red-200'
-											: event.status === 'postponed'
-												? 'bg-yellow-900/50 text-yellow-200'
-												: 'bg-gray-900/50 text-gray-200'}"
-							>
-								{event.status}
-							</span>
+							<!-- Inline quick-edit: changing the select immediately saves via ?/updateStatus. -->
+							<form method="POST" action="?/updateStatus" use:enhance class="inline-flex">
+								<input type="hidden" name="id" value={event.id} />
+								<select
+									name="status"
+									value={event.status}
+									onchange={(e) => e.currentTarget.form?.requestSubmit()}
+									aria-label={m.status()}
+									title={m.status()}
+									class="cursor-pointer rounded-full border-0 px-2 py-0.5 text-xs leading-5 font-semibold focus:ring-2 focus:ring-yellow-500 focus:outline-none {statusBadgeClass(
+										event.status
+									)}"
+								>
+									{#each statusOptions as s (s)}
+										<option value={s} class="bg-slate-800 text-white">{s}</option>
+									{/each}
+								</select>
+							</form>
 						</td>
 						<td class="min-w-max px-4 py-1 whitespace-nowrap">
 							<span


### PR DESCRIPTION
On `/admin/events`, the status column was a read-only badge — changing status meant opening the full editor and re-saving everything. Now it's an inline **dropdown that saves immediately** on change.

- New `updateStatus` form action (admin/editor only) → reuses the `updateEvent` data layer (partial scalar update, validated, `edit_history` attribution `admin:status-quickedit`).
- The select auto-submits via `use:enhance`; the row refreshes in place and keeps the status-colored pill styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)