### PR TITLE
feat(mcp): ingest remote image URLs into S3 on create/update_event

### DIFF
--- a/src/lib/server/data/events.ts
+++ b/src/lib/server/data/events.ts
@@ -3,7 +3,7 @@ import type { Event, EventOrganizer } from '$lib/server/db/schemas/game/event';
 import type { Organizer } from '$lib/server/db/schemas/game/organizer';
 import { db } from '../db';
 import * as table from '$lib/server/db/schema';
-import { processImageURL } from '$lib/server/storage';
+import { processImageURL, ingestImageIfUrl } from '$lib/server/storage';
 import type { Region } from '$lib/data/game';
 import { eq, or, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
@@ -218,6 +218,8 @@ export async function createEvent(
 	}
 
 	const id = randomUUID();
+	// Store a remote image URL in our own S3 (returns a key) instead of hotlinking.
+	const image = await ingestImageIfUrl(data.image);
 	const dbEvent = toDatabaseEvent({
 		name: data.name,
 		slug: data.slug,
@@ -225,7 +227,7 @@ export async function createEvent(
 		server: data.server,
 		format: data.format,
 		region: data.region,
-		image: data.image,
+		image,
 		status: data.status,
 		capacity: data.capacity ?? 0,
 		date: data.date,
@@ -342,6 +344,11 @@ export async function updateEvent(
 			.where(eq(table.event.slug, fields.slug))
 			.limit(1);
 		if (dupe) throw new Error(`An event with slug "${fields.slug}" already exists`);
+	}
+
+	// Store a remote image URL in our own S3 (returns a key) instead of hotlinking.
+	if (fields.image !== undefined) {
+		fields.image = await ingestImageIfUrl(fields.image);
 	}
 
 	const columns = [

--- a/src/lib/server/storage-ssrf.test.ts
+++ b/src/lib/server/storage-ssrf.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'bun:test';
+import { isPrivateIp } from './storage-ssrf';
+
+describe('isPrivateIp', () => {
+	it('rejects IPv4 loopback / private / link-local / CGNAT / reserved', () => {
+		for (const ip of [
+			'127.0.0.1',
+			'127.1.2.3',
+			'0.0.0.0',
+			'10.0.0.5',
+			'172.16.0.1',
+			'172.31.255.255',
+			'192.168.1.1',
+			'169.254.169.254', // cloud metadata
+			'100.64.0.1', // CGNAT
+			'224.0.0.1', // multicast
+			'255.255.255.255'
+		]) {
+			expect(isPrivateIp(ip)).toBe(true);
+		}
+	});
+
+	it('allows public IPv4', () => {
+		for (const ip of [
+			'8.8.8.8',
+			'1.1.1.1',
+			'104.244.42.1',
+			'172.15.0.1',
+			'172.32.0.1',
+			'100.63.0.1',
+			'100.128.0.1'
+		]) {
+			expect(isPrivateIp(ip)).toBe(false);
+		}
+	});
+
+	it('rejects IPv6 loopback / ULA / link-local (incl. brackets + zone id)', () => {
+		for (const ip of ['::1', '[::1]', '::', 'fe80::1', 'fe80::1%eth0', 'fc00::1', 'fd12:3456::1']) {
+			expect(isPrivateIp(ip)).toBe(true);
+		}
+	});
+
+	it('handles IPv4-mapped IPv6 by the embedded v4', () => {
+		expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+		expect(isPrivateIp('::ffff:10.0.0.1')).toBe(true);
+		expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
+	});
+
+	it('allows public IPv6', () => {
+		expect(isPrivateIp('2606:4700:4700::1111')).toBe(false);
+		expect(isPrivateIp('2001:4860:4860::8888')).toBe(false);
+	});
+});

--- a/src/lib/server/storage-ssrf.ts
+++ b/src/lib/server/storage-ssrf.ts
@@ -1,0 +1,31 @@
+/**
+ * SSRF address denylist — pure (no env/SDK imports) so it is unit-testable.
+ *
+ * Used by the image-ingestion fetch in `./storage`: a resolved address that is
+ * loopback/private/link-local/CGNAT/reserved must never be connected to.
+ */
+export function isPrivateIp(ip: string): boolean {
+	const addr = ip
+		.toLowerCase()
+		.replace(/^\[|\]$/g, '')
+		.replace(/%.*$/, ''); // strip brackets + IPv6 zone id
+	const v4 = addr.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+	if (v4) {
+		const a = Number(v4[1]);
+		const b = Number(v4[2]);
+		return (
+			a === 0 ||
+			a === 10 ||
+			a === 127 ||
+			(a === 169 && b === 254) || // link-local
+			(a === 172 && b >= 16 && b <= 31) ||
+			(a === 192 && b === 168) ||
+			(a === 100 && b >= 64 && b <= 127) || // CGNAT
+			a >= 224 // multicast / reserved
+		);
+	}
+	if (addr === '::1' || addr === '::') return true;
+	if (addr.startsWith('::ffff:')) return isPrivateIp(addr.slice(7)); // IPv4-mapped IPv6
+	if (addr.startsWith('fe80') || addr.startsWith('fc') || addr.startsWith('fd')) return true; // link-local / ULA
+	return false;
+}

--- a/src/lib/server/storage.ts
+++ b/src/lib/server/storage.ts
@@ -33,6 +33,88 @@ export async function uploadImage(file: File, key: string): Promise<string> {
 	return key;
 }
 
+const MAX_INGEST_BYTES = 8 * 1024 * 1024; // 8 MB
+const INGEST_TYPE_EXT: Record<string, string> = {
+	'image/png': 'png',
+	'image/jpeg': 'jpg',
+	'image/webp': 'webp',
+	'image/gif': 'gif',
+	'image/avif': 'avif'
+};
+
+/** SSRF guard: reject loopback/private/link-local hosts before fetching a remote URL. */
+function isDisallowedHost(hostname: string): boolean {
+	const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+	if (
+		h === 'localhost' ||
+		h.endsWith('.localhost') ||
+		h.endsWith('.internal') ||
+		h.endsWith('.local') ||
+		h === '::1' ||
+		h.startsWith('fe80:') ||
+		h.startsWith('fc') ||
+		h.startsWith('fd')
+	) {
+		return true;
+	}
+	const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+	if (m) {
+		const a = Number(m[1]);
+		const b = Number(m[2]);
+		if (
+			a === 10 ||
+			a === 127 ||
+			a === 0 ||
+			(a === 192 && b === 168) ||
+			(a === 172 && b >= 16 && b <= 31) ||
+			(a === 169 && b === 254)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Fetch a remote image by URL and store it in our S3, returning the storage key.
+ * SSRF-guarded: https only, no loopback/private hosts, no redirects, must be an
+ * image content-type, size-capped. Lets an MCP/editor edit ingest an external
+ * banner into our own storage instead of hotlinking a CDN URL that can rot.
+ */
+export async function ingestImageUrl(url: string, prefix = 'events'): Promise<string> {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new Error(`Invalid image URL: ${url}`);
+	}
+	if (parsed.protocol !== 'https:') throw new Error('Image URL must be https');
+	if (isDisallowedHost(parsed.hostname)) throw new Error('Image URL host is not allowed');
+
+	const res = await fetch(parsed, { redirect: 'error' });
+	if (!res.ok) throw new Error(`Failed to fetch image (HTTP ${res.status})`);
+
+	const type = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
+	const ext = INGEST_TYPE_EXT[type];
+	if (!ext) throw new Error(`Unsupported image content-type: ${type || 'unknown'}`);
+
+	const buffer = Buffer.from(await res.arrayBuffer());
+	if (buffer.byteLength > MAX_INGEST_BYTES) {
+		throw new Error(`Image too large (max ${MAX_INGEST_BYTES / (1024 * 1024)} MB)`);
+	}
+
+	const key = `${prefix}/${crypto.randomUUID()}.${ext}`;
+	await s3Client.send(
+		new PutObjectCommand({ Bucket: S3_BUCKET_NAME, Key: key, Body: buffer, ContentType: type })
+	);
+	return key;
+}
+
+/** If `value` is an http(s) URL, ingest it into storage and return the key; otherwise return as-is. */
+export async function ingestImageIfUrl(value: string): Promise<string> {
+	return value.startsWith('http') ? ingestImageUrl(value) : value;
+}
+
 export async function getSignedImageUrl(key: string): Promise<string> {
 	const command = new GetObjectCommand({
 		Bucket: S3_BUCKET_NAME,

--- a/src/lib/server/storage.ts
+++ b/src/lib/server/storage.ts
@@ -1,5 +1,8 @@
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import https from 'node:https';
+import dns from 'node:dns';
+import { isPrivateIp } from './storage-ssrf';
 import {
 	S3_BUCKET_NAME,
 	S3_ACCESS_KEY_ID,
@@ -42,44 +45,99 @@ const INGEST_TYPE_EXT: Record<string, string> = {
 	'image/avif': 'avif'
 };
 
-/** SSRF guard: reject loopback/private/link-local hosts before fetching a remote URL. */
-function isDisallowedHost(hostname: string): boolean {
-	const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-	if (
-		h === 'localhost' ||
-		h.endsWith('.localhost') ||
-		h.endsWith('.internal') ||
-		h.endsWith('.local') ||
-		h === '::1' ||
-		h.startsWith('fe80:') ||
-		h.startsWith('fc') ||
-		h.startsWith('fd')
-	) {
-		return true;
-	}
-	const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-	if (m) {
-		const a = Number(m[1]);
-		const b = Number(m[2]);
-		if (
-			a === 10 ||
-			a === 127 ||
-			a === 0 ||
-			(a === 192 && b === 168) ||
-			(a === 172 && b >= 16 && b <= 31) ||
-			(a === 169 && b === 254)
-		) {
-			return true;
+/**
+ * Custom DNS lookup that resolves the host, REJECTS if ANY resolved address is
+ * non-public, and otherwise hands a validated address to the socket. Because the
+ * value the socket connects to IS the value we validated (one atomic resolve),
+ * there is no check-then-connect window — this defeats DNS rebinding, not just a
+ * literal private hostname.
+ */
+function pinnedPublicLookup(
+	hostname: string,
+	options: dns.LookupOptions,
+	callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void
+): void {
+	dns.lookup(hostname, { all: true, family: options.family ?? 0 }, (err, addresses) => {
+		if (err) return callback(err, '', 0);
+		if (addresses.length === 0) {
+			return callback(
+				new Error(`Could not resolve host: ${hostname}`) as NodeJS.ErrnoException,
+				'',
+				0
+			);
 		}
-	}
-	return false;
+		for (const a of addresses) {
+			if (isPrivateIp(a.address)) {
+				return callback(
+					new Error(`Host ${hostname} resolves to a non-public address`) as NodeJS.ErrnoException,
+					'',
+					0
+				);
+			}
+		}
+		callback(null, addresses[0].address, addresses[0].family);
+	});
+}
+
+interface FetchedImage {
+	buffer: Buffer;
+	type: string;
+	ext: string;
+}
+
+/**
+ * GET an https image with all SSRF/DoS guards applied: the connection is pinned
+ * to a validated public IP (no rebinding), redirects are refused, the
+ * content-type must be an allowed image, and the size cap is enforced from
+ * Content-Length AND while streaming (so the body is never fully buffered first).
+ */
+function fetchGuardedImage(parsed: URL): Promise<FetchedImage> {
+	return new Promise<FetchedImage>((resolve, reject) => {
+		const req = https.get(
+			parsed,
+			{ lookup: pinnedPublicLookup, servername: parsed.hostname, timeout: 15_000 },
+			(res) => {
+				const status = res.statusCode ?? 0;
+				const failWith = (msg: string) => {
+					res.destroy();
+					reject(new Error(msg));
+				};
+				if (status >= 300 && status < 400)
+					return failWith('Image URL redirected; redirects are not allowed');
+				if (status !== 200) return failWith(`Failed to fetch image (HTTP ${status})`);
+
+				const type = String(res.headers['content-type'] ?? '')
+					.split(';')[0]
+					.trim()
+					.toLowerCase();
+				const ext = INGEST_TYPE_EXT[type];
+				if (!ext) return failWith(`Unsupported image content-type: ${type || 'unknown'}`);
+
+				const tooLarge = `Image too large (max ${MAX_INGEST_BYTES / (1024 * 1024)} MB)`;
+				const declared = Number(res.headers['content-length']);
+				if (Number.isFinite(declared) && declared > MAX_INGEST_BYTES) return failWith(tooLarge);
+
+				const chunks: Buffer[] = [];
+				let total = 0;
+				res.on('data', (chunk: Buffer) => {
+					total += chunk.length;
+					if (total > MAX_INGEST_BYTES) return failWith(tooLarge);
+					chunks.push(chunk);
+				});
+				res.on('end', () => resolve({ buffer: Buffer.concat(chunks), type, ext }));
+				res.on('error', reject);
+			}
+		);
+		req.on('timeout', () => req.destroy(new Error('Image fetch timed out')));
+		req.on('error', reject);
+	});
 }
 
 /**
  * Fetch a remote image by URL and store it in our S3, returning the storage key.
- * SSRF-guarded: https only, no loopback/private hosts, no redirects, must be an
- * image content-type, size-capped. Lets an MCP/editor edit ingest an external
- * banner into our own storage instead of hotlinking a CDN URL that can rot.
+ * https only; the fetch is SSRF-hardened (see `fetchGuardedImage`). Lets an
+ * MCP/editor edit ingest an external banner into our own storage instead of
+ * hotlinking a CDN URL that can rot.
  */
 export async function ingestImageUrl(url: string, prefix = 'events'): Promise<string> {
 	let parsed: URL;
@@ -89,20 +147,8 @@ export async function ingestImageUrl(url: string, prefix = 'events'): Promise<st
 		throw new Error(`Invalid image URL: ${url}`);
 	}
 	if (parsed.protocol !== 'https:') throw new Error('Image URL must be https');
-	if (isDisallowedHost(parsed.hostname)) throw new Error('Image URL host is not allowed');
 
-	const res = await fetch(parsed, { redirect: 'error' });
-	if (!res.ok) throw new Error(`Failed to fetch image (HTTP ${res.status})`);
-
-	const type = (res.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
-	const ext = INGEST_TYPE_EXT[type];
-	if (!ext) throw new Error(`Unsupported image content-type: ${type || 'unknown'}`);
-
-	const buffer = Buffer.from(await res.arrayBuffer());
-	if (buffer.byteLength > MAX_INGEST_BYTES) {
-		throw new Error(`Image too large (max ${MAX_INGEST_BYTES / (1024 * 1024)} MB)`);
-	}
-
+	const { buffer, type, ext } = await fetchGuardedImage(parsed);
 	const key = `${prefix}/${crypto.randomUUID()}.${ext}`;
 	await s3Client.send(
 		new PutObjectCommand({ Bucket: S3_BUCKET_NAME, Key: key, Body: buffer, ContentType: type })


### PR DESCRIPTION
There's no PAT/MCP path to *store* an image today (only session-auth `/api/upload`), so MCP-created events are stuck with placeholder/hotlinked images. This makes `create_event` / `update_event` ingest an `http(s)` `image` value into our own S3 and save the storage key (so `processImageURL` serves a signed URL) instead of hotlinking a CDN URL that can rot.

- `ingestImageUrl(url)` in `storage.ts`: fetch → store in S3 → return key.
- **SSRF-guarded:** https-only, loopback/private/link-local hosts blocked, redirects disallowed, image content-type required, 8 MB cap.
- `ingestImageIfUrl` is applied in `createEvent` + `updateEvent`; **storage keys pass through unchanged**, so the admin upload flow is unaffected.

Enables backfilling real tournament banners via `update_event(slug, {image: <url>})`. Verified the Origami Cup 4 + EmikoAi banners are direct `image/jpeg`, no redirect, <8 MB.

`bun test src/lib/server/mcp` 42 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)