### PR TITLE
fix(mcp): handle Node all:true lookup in image-ingestion SSRF guard

### DIFF
--- a/src/lib/server/storage.ts
+++ b/src/lib/server/storage.ts
@@ -55,7 +55,11 @@ const INGEST_TYPE_EXT: Record<string, string> = {
 function pinnedPublicLookup(
 	hostname: string,
 	options: dns.LookupOptions,
-	callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void
+	callback: (
+		err: NodeJS.ErrnoException | null,
+		address: string | dns.LookupAddress[],
+		family?: number
+	) => void
 ): void {
 	dns.lookup(hostname, { all: true, family: options.family ?? 0 }, (err, addresses) => {
 		if (err) return callback(err, '', 0);
@@ -75,7 +79,13 @@ function pinnedPublicLookup(
 				);
 			}
 		}
-		callback(null, addresses[0].address, addresses[0].family);
+		// Node may call lookup with `all` (Happy Eyeballs / autoSelectFamily on
+		// Node 22) and then expects the FULL array; otherwise a single address.
+		if (options.all) {
+			callback(null, addresses);
+		} else {
+			callback(null, addresses[0].address, addresses[0].family);
+		}
 	});
 }
 


### PR DESCRIPTION
The image ingestion (PR #64) failed on every call with `Invalid IP address: undefined`.

**Cause:** the custom DNS `lookup` returned a single `(address, family)`, but Node 22's `autoSelectFamily`/Happy-Eyeballs invokes `lookup` with `all: true` and then expects the **full `LookupAddress[]` array**. Node read `undefined` as the IP → connect failed.

**Fix:** honor `options.all` — return the validated array when asked, else the single address. SSRF validation (reject if *any* resolved address is non-public) is unchanged.

**Verified locally** against the real banners — bilibili (`image/avif`), Origami + EmikoAi (`image/jpeg`) all fetch; `https://localhost/` still blocked (`private`).

Server-side only, so no MCP reconnect needed after deploy — `update_event` can be re-run immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)