### PR TITLE
feat(events): optional banner image + branded placeholder

### DIFF
--- a/src/lib/components/EventCard.svelte
+++ b/src/lib/components/EventCard.svelte
@@ -25,6 +25,7 @@
 	import type { Event } from '$lib/data/events';
 	import { m } from '$lib/paraglide/messages';
 	import { safeFormatEventDate } from '$lib/utils/date';
+	import { EVENT_PLACEHOLDER_IMAGE } from '$lib/consts';
 
 	import IconParkSolidCalendar from '~icons/icon-park-solid/calendar';
 	import IconParkSolidPeoples from '~icons/icon-park-solid/peoples';
@@ -54,7 +55,7 @@
 		}}
 	>
 		<img
-			src={event.imageURL ?? event.image}
+			src={event.imageURL || event.image || EVENT_PLACEHOLDER_IMAGE}
 			alt={event.name}
 			class="max-h-40 w-full max-w-full object-cover sm:max-w-64"
 		/>

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -10,3 +10,6 @@ export const STRINOVA_ESPORTS_HUB_DISCORD_URL = 'https://discord.gg/mY8DMatXM4';
 export const LEMON_TV_QQ_URL = 'https://qm.qq.com/q/ligXzoAg6c';
 
 export const GITHUB_REPO_URL = 'https://github.com/LemonTV-win/LemonTV';
+
+/** Branded fallback banner shown for events that have no image. */
+export const EVENT_PLACEHOLDER_IMAGE = '/event-placeholder.svg';

--- a/src/lib/server/data/events.ts
+++ b/src/lib/server/data/events.ts
@@ -153,7 +153,8 @@ export interface CreateEventInput {
 	server: string;
 	format: string;
 	region: Region;
-	image: string;
+	/** Optional — omit (or pass empty) to create an event with no banner; a placeholder is shown. */
+	image?: string;
 	status: string;
 	capacity?: number;
 	date: string;
@@ -183,7 +184,6 @@ export async function createEvent(
 		['server', data.server],
 		['format', data.format],
 		['region', data.region],
-		['image', data.image],
 		['status', data.status],
 		['date', data.date]
 	];
@@ -218,8 +218,9 @@ export async function createEvent(
 	}
 
 	const id = randomUUID();
-	// Store a remote image URL in our own S3 (returns a key) instead of hotlinking.
-	const image = await ingestImageIfUrl(data.image);
+	// Optional banner: empty when omitted (a placeholder renders). A remote URL is
+	// ingested into our own S3 (returns a key) instead of being hotlinked.
+	const image = data.image ? await ingestImageIfUrl(data.image) : '';
 	const dbEvent = toDatabaseEvent({
 		name: data.name,
 		slug: data.slug,

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -125,7 +125,8 @@ export const TOOLS: McpTool[] = [
 				date: { type: 'string', description: 'YYYY-MM-DD or a range YYYY-MM-DD/YYYY-MM-DD.' },
 				image: {
 					type: 'string',
-					description: 'Banner/logo URL (a placeholder URL is acceptable).'
+					description:
+						'Optional banner/logo URL — omit to create the event with no banner (a branded placeholder is shown). An https URL is fetched and stored in our own storage.'
 				},
 				official: {
 					type: 'boolean',
@@ -148,7 +149,7 @@ export const TOOLS: McpTool[] = [
 					description: 'Related links (optional).'
 				}
 			},
-			required: ['name', 'slug', 'server', 'format', 'region', 'status', 'date', 'image'],
+			required: ['name', 'slug', 'server', 'format', 'region', 'status', 'date'],
 			additionalProperties: false
 		},
 		handler: async (args, identity) => {
@@ -164,7 +165,7 @@ export const TOOLS: McpTool[] = [
 					region: requireString(args, 'region') as never,
 					status: requireString(args, 'status'),
 					date: requireString(args, 'date'),
-					image: requireString(args, 'image'),
+					image: typeof args.image === 'string' ? args.image : undefined,
 					official: Boolean(args.official ?? false),
 					capacity: typeof args.capacity === 'number' ? args.capacity : 0,
 					organizerIds: Array.isArray(args.organizerIds) ? (args.organizerIds as string[]) : [],

--- a/src/routes/(content)/events/[id]/+page.svelte
+++ b/src/routes/(content)/events/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import type { Stage } from '$lib/data/events';
 
 	import { m } from '$lib/paraglide/messages';
+	import { EVENT_PLACEHOLDER_IMAGE } from '$lib/consts';
 
 	let { data }: PageProps = $props();
 
@@ -97,7 +98,7 @@
 	<Breadcrumbs currentTitle={data.event.name} />
 	<div
 		class="banner flex min-h-48 flex-col gap-2 bg-cover bg-top p-4 text-white"
-		style:--banner-image={`url(${data.event.imageURL})`}
+		style:--banner-image={`url(${data.event.imageURL || EVENT_PLACEHOLDER_IMAGE})`}
 	>
 		<h1 class="my-2 flex items-center gap-2 text-3xl font-bold">
 			{data.event.name}

--- a/src/routes/(content)/organizers/[slug]/+page.svelte
+++ b/src/routes/(content)/organizers/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import IconParkSolidLocalPin from '~icons/icon-park-solid/local-pin';
 	import IconParkSolidComputer from '~icons/icon-park-solid/computer';
 	import { m } from '$lib/paraglide/messages';
+	import { EVENT_PLACEHOLDER_IMAGE } from '$lib/consts';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import OrganizerTypeBadge from '$lib/components/OrganizerTypeBadge.svelte';
 	import ContentActionLink from '$lib/components/ContentActionLink.svelte';
@@ -58,7 +59,11 @@
 						class="glass-card group block overflow-hidden transition-transform hover:scale-[1.02]"
 					>
 						<div class="relative h-48">
-							<img src={event.imageURL} alt={event.name} class="h-full w-full object-cover" />
+							<img
+								src={event.imageURL || EVENT_PLACEHOLDER_IMAGE}
+								alt={event.name}
+								class="h-full w-full object-cover"
+							/>
 							<div class="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent"></div>
 							<div class="absolute right-0 bottom-0 left-0 p-4 text-white">
 								<h3 class="text-xl font-bold">{event.name}</h3>

--- a/src/routes/(content)/players/[id]/+page.svelte
+++ b/src/routes/(content)/players/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { error } from '@sveltejs/kit';
 	import type { PageProps } from './$types';
 	import { m } from '$lib/paraglide/messages.js';
+	import { EVENT_PLACEHOLDER_IMAGE } from '$lib/consts';
 	import MapIcon from '$lib/components/MapIcon.svelte';
 	import MatchCard from '$lib/components/MatchCard.svelte';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
@@ -140,7 +141,11 @@
 									>
 										<a href="/events/{event.slug}" class="contents">
 											<div class="flex h-full w-full items-center justify-center bg-gray-700">
-												<img src={event.imageURL} alt={event.name} class="w-full object-cover" />
+												<img
+													src={event.imageURL || EVENT_PLACEHOLDER_IMAGE}
+													alt={event.name}
+													class="w-full object-cover"
+												/>
 											</div>
 											<div class="h-full p-4 text-white">{event.name}</div>
 										</a>

--- a/src/routes/(user)/admin/events/+page.server.ts
+++ b/src/routes/(user)/admin/events/+page.server.ts
@@ -290,7 +290,7 @@ export const actions = {
 			!eventData.server ||
 			!eventData.format ||
 			!eventData.region ||
-			!eventData.image ||
+			// image is optional — a placeholder renders when absent
 			!eventData.status ||
 			// !eventData.capacity ||
 			!eventData.date
@@ -301,7 +301,6 @@ export const actions = {
 			if (!eventData.server) missingFields.push('server');
 			if (!eventData.format) missingFields.push('format');
 			if (!eventData.region) missingFields.push('region');
-			if (!eventData.image) missingFields.push('image');
 			if (!eventData.status) missingFields.push('status');
 			// if (!eventData.capacity) missingFields.push('capacity');
 			if (!eventData.date) missingFields.push('date');
@@ -435,7 +434,7 @@ export const actions = {
 			!eventData.server ||
 			!eventData.format ||
 			!eventData.region ||
-			!eventData.image ||
+			// image is optional — a placeholder renders when absent
 			!eventData.status ||
 			// !eventData.capacity ||
 			!eventData.date
@@ -447,7 +446,6 @@ export const actions = {
 			if (!eventData.server) missingFields.push('server');
 			if (!eventData.format) missingFields.push('format');
 			if (!eventData.region) missingFields.push('region');
-			if (!eventData.image) missingFields.push('image');
 			if (!eventData.status) missingFields.push('status');
 			// if (!eventData.capacity) missingFields.push('capacity');
 			if (!eventData.date) missingFields.push('date');

--- a/src/routes/(user)/admin/events/+page.svelte
+++ b/src/routes/(user)/admin/events/+page.svelte
@@ -18,6 +18,7 @@
 	import OrganizerChip from '$lib/components/OrganizerChip.svelte';
 	import ContentActionLink from '$lib/components/ContentActionLink.svelte';
 	import { safeFormatEventDate, safeGetTimestamp } from '$lib/utils/date';
+	import { EVENT_PLACEHOLDER_IMAGE } from '$lib/consts';
 	import type { Region } from '$lib/data/game';
 
 	let { data }: { data: PageData } = $props();
@@ -415,13 +416,11 @@
 					<tr class="border-b-1 border-gray-500 bg-gray-800 px-4 py-2 shadow-2xl">
 						<td class="min-w-max overflow-hidden px-4 py-1">
 							<div class="flex min-w-max items-center">
-								{#if event.imageURL}
-									<img
-										class="mr-3 h-10 w-16 flex-shrink-0 rounded-md object-cover"
-										src={event.imageURL}
-										alt={event.name}
-									/>
-								{/if}
+								<img
+									class="mr-3 h-10 w-16 flex-shrink-0 rounded-md object-cover"
+									src={event.imageURL || EVENT_PLACEHOLDER_IMAGE}
+									alt={event.name}
+								/>
 								<div class="flex min-w-max flex-shrink-0 flex-col">
 									<div class="flex-shrink-0 whitespace-nowrap text-white">{event.name}</div>
 									<a

--- a/src/routes/(user)/admin/matches/EventButtonCard.svelte
+++ b/src/routes/(user)/admin/matches/EventButtonCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
 	import { safeFormatEventDate } from '$lib/utils/date';
+	import { EVENT_PLACEHOLDER_IMAGE } from '$lib/consts';
 
 	let {
 		event,
@@ -36,9 +37,11 @@
 	}}
 >
 	<div class="mb-2 flex items-center gap-3">
-		{#if event.imageURL}
-			<img src={event.imageURL} alt={event.name} class="h-12 w-12 rounded-lg object-cover" />
-		{/if}
+		<img
+			src={event.imageURL || EVENT_PLACEHOLDER_IMAGE}
+			alt={event.name}
+			class="h-12 w-12 rounded-lg object-cover"
+		/>
 		<div>
 			<h3 class="font-semibold text-white transition-colors group-hover:text-yellow-400">
 				{event.name}

--- a/static/event-placeholder.svg
+++ b/static/event-placeholder.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="No banner">
+	<defs>
+		<linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+			<stop offset="0" stop-color="#1c1c22" />
+			<stop offset="1" stop-color="#0f0f13" />
+		</linearGradient>
+		<radialGradient id="glow" cx="50%" cy="40%" r="42%">
+			<stop offset="0" stop-color="#fbbf24" stop-opacity="0.16" />
+			<stop offset="1" stop-color="#fbbf24" stop-opacity="0" />
+		</radialGradient>
+	</defs>
+	<rect width="1200" height="800" fill="url(#bg)" />
+	<rect width="1200" height="800" fill="url(#glow)" />
+	<g transform="translate(600 350) rotate(-28)">
+		<path d="M126 0 l40 -4 -12 17 z" fill="#f59e0b" />
+		<path d="M-126 0 l-40 4 12 -17 z" fill="#f59e0b" />
+		<ellipse cx="0" cy="0" rx="124" ry="84" fill="#fbbf24" />
+		<ellipse cx="0" cy="0" rx="124" ry="84" fill="none" stroke="#f59e0b" stroke-width="6" opacity="0.55" />
+		<ellipse cx="-42" cy="-30" rx="38" ry="20" fill="#ffffff" opacity="0.28" />
+		<path d="M70 -70 q44 -34 84 -20 q-14 42 -56 50 q-24 -10 -28 -30 z" fill="#4ade80" />
+		<path d="M78 -64 q30 -16 64 -14" fill="none" stroke="#16a34a" stroke-width="4" opacity="0.6" />
+	</g>
+	<text x="600" y="540" text-anchor="middle" font-family="Inter, 'Segoe UI', system-ui, sans-serif" font-size="48" font-weight="800" letter-spacing="1" fill="#fbbf24" opacity="0.92">LemonTV</text>
+	<text x="600" y="588" text-anchor="middle" font-family="Inter, 'Segoe UI', system-ui, sans-serif" font-size="26" font-weight="500" letter-spacing="3" fill="#a1a1aa" opacity="0.65">NO BANNER</text>
+</svg>


### PR DESCRIPTION
Events no longer require a banner image. Omit it and a **branded placeholder** renders everywhere instead of a broken/empty `<img>` (or a throwaway `placehold.co` URL).

- **`create_event` (MCP)** + **`createEvent` (data layer)**: `image` is now optional — omit → stored empty; an `https` URL is still ingested into S3 as before.
- **`static/event-placeholder.svg`** — lightweight branded SVG (lemon on a dark gradient, "LemonTV / NO BANNER"), served at `/event-placeholder.svg`.
- Fallback (`EVENT_PLACEHOLDER_IMAGE`) applied at every render site: `EventCard`, event-detail banner, player-profile attended events, admin events list, admin match event cards.

No schema change (empty string = no banner). `bun test src/lib/server/mcp` 42 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)