### PR TITLE
fix(players): friendly game-account conflict errors + duplicate validation

### DIFF
--- a/src/lib/server/data/players.ts
+++ b/src/lib/server/data/players.ts
@@ -10,7 +10,12 @@ import {
 	playerAdditionalNationality
 } from '$lib/server/db/schema';
 import { eq, or, and, inArray, sql, desc } from 'drizzle-orm';
-import { getGameAccountServer, type Player, type PlayerTeam } from '$lib/data/players';
+import {
+	getGameAccountServer,
+	type GameAccountServer,
+	type Player,
+	type PlayerTeam
+} from '$lib/data/players';
 import { randomUUID } from 'node:crypto';
 import type { Character, GameMap, Region } from '$lib/data/game';
 import type { TCountryCode } from 'countries-list';
@@ -956,6 +961,58 @@ export async function getPlayerKD(playerId: string): Promise<number> {
 		')'
 	);
 	return kdRatio;
+}
+
+export interface GameAccountConflict {
+	server: GameAccountServer;
+	accountId: number;
+	ownerPlayerId: string;
+	ownerName: string;
+	ownerSlug: string;
+}
+
+/**
+ * Find game accounts that are already linked to a different player.
+ *
+ * A game account is globally unique per (server, accountId) — see the composite primary key on the
+ * `game_account` table. The CN server (CalabiYau) and the international server (Strinova) are
+ * separate, so the same UID on both servers is fine; what collides is the same UID on the same
+ * server. This lets callers return a helpful error naming the owning player instead of surfacing a
+ * raw SQL constraint violation.
+ *
+ * @param gameAccounts - The accounts being created/updated for a player
+ * @param excludePlayerId - When updating, the player whose own accounts should be ignored
+ */
+export async function findGameAccountConflicts(
+	gameAccounts: Player['gameAccounts'] | undefined,
+	excludePlayerId?: string
+): Promise<GameAccountConflict[]> {
+	if (!gameAccounts?.length) return [];
+
+	const pairs = gameAccounts.map((account) => ({
+		server: getGameAccountServer(account.region),
+		accountId: account.accountId
+	}));
+
+	const rows = await db
+		.select({
+			server: gameAccount.server,
+			accountId: gameAccount.accountId,
+			ownerPlayerId: gameAccount.playerId,
+			ownerName: player.name,
+			ownerSlug: player.slug
+		})
+		.from(gameAccount)
+		.innerJoin(player, eq(player.id, gameAccount.playerId))
+		.where(
+			or(
+				...pairs.map((p) =>
+					and(eq(gameAccount.server, p.server), eq(gameAccount.accountId, p.accountId))
+				)
+			)
+		);
+
+	return rows.filter((row) => row.ownerPlayerId !== excludePlayerId) as GameAccountConflict[];
 }
 
 export async function createPlayer(

--- a/src/routes/(user)/admin/players/+page.server.ts
+++ b/src/routes/(user)/admin/players/+page.server.ts
@@ -2,7 +2,14 @@ import { fail } from '@sveltejs/kit';
 import * as schema from '$lib/server/db/schema';
 import { sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
-import { createPlayer, updatePlayer, getPlayers, deletePlayer } from '$lib/server/data/players';
+import {
+	createPlayer,
+	updatePlayer,
+	getPlayers,
+	deletePlayer,
+	findGameAccountConflicts,
+	type GameAccountConflict
+} from '$lib/server/data/players';
 import type { Player } from '$lib/data/players';
 import type { TCountryCode } from 'countries-list';
 import type { User, UserRole } from '$lib/data/user';
@@ -66,6 +73,19 @@ export const load: PageServerLoad = async () => {
 	};
 };
 
+function formatGameAccountConflictError(conflicts: GameAccountConflict[]): string {
+	return (
+		'Cannot save: ' +
+		conflicts
+			.map(
+				(c) =>
+					`game account UID ${c.accountId} on the ${c.server} server is already linked to player "${c.ownerName}" (${c.ownerSlug})`
+			)
+			.join('; ') +
+		'.'
+	);
+}
+
 export const actions = {
 	create: async ({ request, locals }) => {
 		const result = checkPermissions(locals, ['admin', 'editor']);
@@ -93,6 +113,13 @@ export const actions = {
 		if (!name || !slug) {
 			return fail(400, {
 				error: 'Name and slug are required'
+			});
+		}
+
+		const createConflicts = await findGameAccountConflicts(gameAccounts);
+		if (createConflicts.length > 0) {
+			return fail(409, {
+				error: formatGameAccountConflictError(createConflicts)
 			});
 		}
 
@@ -176,6 +203,9 @@ export const actions = {
 					userMessage = 'This user is already linked to another player.';
 				} else if (errorMessage.includes('player_social_account')) {
 					userMessage = 'This social account is already linked to another player.';
+				} else if (errorMessage.includes('game_account')) {
+					userMessage =
+						'A game account UID is already linked to another player (each UID must be unique per server).';
 				}
 
 				return fail(409, {
@@ -216,6 +246,13 @@ export const actions = {
 		if (!id || !name || !slug) {
 			return fail(400, {
 				error: 'ID, name and slug are required'
+			});
+		}
+
+		const updateConflicts = await findGameAccountConflicts(gameAccounts, id);
+		if (updateConflicts.length > 0) {
+			return fail(409, {
+				error: formatGameAccountConflictError(updateConflicts)
 			});
 		}
 
@@ -319,6 +356,9 @@ export const actions = {
 					userMessage = 'This user is already linked to another player.';
 				} else if (errorMessage.includes('player_social_account')) {
 					userMessage = 'This social account is already linked to another player.';
+				} else if (errorMessage.includes('game_account')) {
+					userMessage =
+						'A game account UID is already linked to another player (each UID must be unique per server).';
 				}
 
 				return fail(409, {

--- a/src/routes/(user)/admin/players/PlayerEdit.svelte
+++ b/src/routes/(user)/admin/players/PlayerEdit.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import type { Player } from '$lib/data/players';
+	import { getGameAccountServer, type Player } from '$lib/data/players';
 	import type { TCountryCode } from 'countries-list';
 	import { m } from '$lib/paraglide/messages';
 	import { getLocale } from '$lib/paraglide/runtime';
@@ -48,6 +48,29 @@
 		player.nationalities?.slice(1) || []
 	);
 	let playerAvatar = $state(player.avatar ?? null);
+
+	// Detect game accounts that collide within the form: the same UID on the same server.
+	// CN (CalabiYau) and international (Strinova) are separate, so the same UID across them is fine.
+	let duplicateGameAccountKeys = $derived.by(() => {
+		const counts = new Map<string, number>();
+		const duplicates = new Set<string>();
+		for (const account of newPlayer.gameAccounts ?? []) {
+			// Skip not-yet-filled rows (new accounts default to accountId 0)
+			if (!account.accountId) continue;
+			const key = `${getGameAccountServer(account.region)}:${account.accountId}`;
+			const next = (counts.get(key) ?? 0) + 1;
+			counts.set(key, next);
+			if (next > 1) duplicates.add(key);
+		}
+		return duplicates;
+	});
+	let hasDuplicateGameAccounts = $derived(duplicateGameAccountKeys.size > 0);
+	function isDuplicateGameAccount(account: { accountId: number; region?: string }) {
+		if (!account.accountId) return false;
+		return duplicateGameAccountKeys.has(
+			`${getGameAccountServer(account.region as Player['gameAccounts'][number]['region'])}:${account.accountId}`
+		);
+	}
 
 	// Pro settings state (optional)
 	let proSettings = $state({
@@ -261,6 +284,13 @@
 		// Prevent submission if there's a pending file upload
 		if (hasFile && !uploaded) {
 			errorMessage = 'Please upload the selected image before saving the player.';
+			return;
+		}
+
+		// Prevent submission if two game accounts share the same UID on the same server
+		if (hasDuplicateGameAccounts) {
+			errorMessage =
+				'Two game accounts have the same UID on the same server. Each UID must be unique per server (CN and international servers are separate).';
 			return;
 		}
 
@@ -503,8 +533,18 @@
 								type="number"
 								id="accountId"
 								bind:value={account.accountId}
-								class="mt-1 block w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-white focus:ring-2 focus:ring-yellow-500 focus:outline-none"
+								class="mt-1 block w-full rounded-md border bg-slate-800 px-3 py-2 text-white focus:ring-2 focus:outline-none {isDuplicateGameAccount(
+									account
+								)
+									? 'border-red-500 focus:ring-red-500'
+									: 'border-slate-700 focus:ring-yellow-500'}"
 							/>
+							{#if isDuplicateGameAccount(account)}
+								<p class="mt-1 text-xs text-red-400">
+									{getGameAccountServer(account.region)} · {m.account_id()}
+									{account.accountId} — duplicate on this server
+								</p>
+							{/if}
 						</div>
 						<div>
 							<label class="block text-sm font-medium text-slate-300" for="currentName">
@@ -852,7 +892,8 @@
 		</button>
 		<button
 			type="submit"
-			class="rounded-md bg-yellow-500 px-4 py-2 font-medium text-black hover:bg-yellow-600"
+			disabled={hasDuplicateGameAccounts}
+			class="rounded-md bg-yellow-500 px-4 py-2 font-medium text-black hover:bg-yellow-600 disabled:cursor-not-allowed disabled:opacity-50"
 		>
 			{player.id ? m.update_player() : m.create_player()}
 		</button>


### PR DESCRIPTION
## Problem

Adding a player whose game-account UID is already linked to another player failed with a raw `Failed query: insert into "game_account" ...` dump. The `game_account` table has a composite primary key `(server, account_id)`, so a UID is globally unique **per server** — CN (CalabiYau) and international (Strinova) are separate, so the same UID across them is fine; the same UID on the same server collides.

## Changes

- **`findGameAccountConflicts()`** (`src/lib/server/data/players.ts`) looks up which player already owns each conflicting `(server, UID)` pair.
- **Create/update actions** (`+page.server.ts`) pre-check and return a clear 409 naming the owning player, e.g. *"game account UID 3160709 on the Strinova server is already linked to player 'Kami神' (Kami神)"*. A `game_account` fallback was added to the catch blocks for races / direct POSTs.
- **`PlayerEdit.svelte`**: detects duplicate `(server, UID)` rows within the form, highlights them, and disables submit until resolved. Unset rows (`accountId` 0) are ignored.

## Verification

- `svelte-check`: 0 errors introduced.
- Reviewed adversarially (drizzle query, excludePlayerId on update, reactivity, accountId-0 false positive fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)