### PR TITLE
feat(players): add "Unknown" game-account region option

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -350,6 +350,7 @@
 	"north_america": "North America (NA)",
 	"asia_pacific": "Asia Pacific (APAC)",
 	"select_region": "Select Region",
+	"region_unknown": "Unknown",
 	"remove_account": "Remove Account",
 	"create_player": "Create Player",
 	"update_player": "Update Player",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -487,6 +487,7 @@
 	"north_america": "北米（NA）",
 	"asia_pacific": "アジア太平洋（APAC）",
 	"select_region": "地域を選択",
+	"region_unknown": "不明",
 	"remove_account": "アカウントを削除",
 	"create_player": "プレイヤーを作成",
 	"update_player": "プレイヤーを更新",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -215,6 +215,7 @@
 	"north_america": "北美 (NA)",
 	"asia_pacific": "亚太 (APAC)",
 	"select_region": "选择地区",
+	"region_unknown": "未知",
 	"remove_account": "删除账号",
 	"create_player": "创建玩家",
 	"update_player": "更新玩家",

--- a/src/lib/data/players.ts
+++ b/src/lib/data/players.ts
@@ -30,7 +30,7 @@ export interface PlayerTeam {
 }
 
 export type GameAccountServer = 'Strinova' | 'CalabiYau';
-export type GameAccountRegion = 'APAC' | 'NA' | 'EU' | 'CN';
+export type GameAccountRegion = 'APAC' | 'NA' | 'EU' | 'CN' | 'Unknown';
 
 export interface GameAccount {
 	server: GameAccountServer;
@@ -47,14 +47,16 @@ export interface GameAccount {
  *
  * CalabiYau only has one region of CN, and Strinova has three of APAC, NA (covers NA and SA), EU (covers EMEA).
  *
- * So if the region is CN, we use CalabiYau, otherwise we use Strinova. If no region is provided, we use Strinova as a default.
+ * So if the region is CN, we use CalabiYau, otherwise we use Strinova. If no region is provided
+ * or the region is Unknown, we use Strinova as a default (the international server is the more
+ * common case, and the account UID still has to be globally unique per server).
  *
  * @param region - The region of the player
  * @returns The server of the player
  */
 export function getGameAccountServer(region: GameAccountRegion | undefined): GameAccountServer {
-	// Default to Strinova if no region is provided
-	if (!region) return 'Strinova';
+	// Default to Strinova if no region is provided or it is unknown
+	if (!region || region === 'Unknown') return 'Strinova';
 	return region === 'CN' ? 'CalabiYau' : 'Strinova';
 }
 

--- a/src/lib/server/db/schemas/game/game-account.ts
+++ b/src/lib/server/db/schemas/game/game-account.ts
@@ -10,7 +10,7 @@ export const gameAccount = sqliteTable(
 			.notNull()
 			.references(() => player.id),
 		currentName: text('current_name').notNull(),
-		region: text('region', { enum: ['APAC', 'NA', 'EU', 'CN'] })
+		region: text('region', { enum: ['APAC', 'NA', 'EU', 'CN', 'Unknown'] })
 	},
 	(table) => [
 		primaryKey({ columns: [table.server, table.accountId] }),

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -25,7 +25,7 @@ import type { McpTool } from './dispatch';
 import { requireString, requireInt, optionalEnum, requireEnum } from './args';
 import { stripUser, stripRosterUserPII } from './project';
 
-const GAME_ACCOUNT_REGIONS = ['APAC', 'NA', 'EU', 'CN'] as const;
+const GAME_ACCOUNT_REGIONS = ['APAC', 'NA', 'EU', 'CN', 'Unknown'] as const;
 const TEAM_REGIONS = ['CN', 'APAC', 'NA', 'SA', 'EU', 'WA', 'Global'] as const;
 const TEAM_PLAYER_ROLES = ['active', 'substitute', 'former', 'coach', 'manager', 'owner'] as const;
 

--- a/src/routes/(user)/admin/players/PlayerEdit.svelte
+++ b/src/routes/(user)/admin/players/PlayerEdit.svelte
@@ -527,6 +527,7 @@
 								class="mt-1 block w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-white focus:ring-2 focus:ring-yellow-500 focus:outline-none"
 							>
 								<option value={undefined}>{m.select_region()}</option>
+								<option value="Unknown">{m.region_unknown()}</option>
 								<optgroup label={m.strinova_server()}>
 									<option value="NA">{m.north_america()}</option>
 									<option value="APAC">{m.asia_pacific()}</option>


### PR DESCRIPTION
## Why

Sometimes a player's region isn't known. This adds an explicit **"Unknown"** choice to the game-account region selector instead of forcing a guess or leaving it blank.

## Changes

- Extend `GameAccountRegion` and the `game_account.region` text enum with `'Unknown'`.
- `getGameAccountServer('Unknown')` → `'Strinova'` (the international server is the common default; the UID is still globally unique per server).
- Localized label: en `Unknown`, zh `未知`, ja `不明` (other locales fall back to base).
- Wire `'Unknown'` into the MCP `GAME_ACCOUNT_REGIONS` constant so the API matches the UI/DB.

## Notes

- **No DB migration needed** — the `region` column is plain `text` with no CHECK constraint; the drizzle enum is type-level only.
- No exhaustive `switch` over `GameAccountRegion` exists (`RegionTag` falls back to raw text).

## Verification

- `svelte-check`: 0 errors introduced.
- Reviewed: migration-free confirmed, region consumers checked, MCP consistency fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)