### PR TITLE
feat(teams): edit roster member status inline

### DIFF
--- a/src/routes/(user)/admin/teams/subforms/TeamPlayerInput.svelte
+++ b/src/routes/(user)/admin/teams/subforms/TeamPlayerInput.svelte
@@ -163,7 +163,15 @@
 					<span class="text-sm text-slate-300">
 						{players.find((p) => p.id === player.playerId)?.name}
 					</span>
-					<span class="text-sm text-slate-300">{player.role}</span>
+					<select
+						bind:value={player.role}
+						aria-label={m.role()}
+						class="block w-full rounded-md border border-slate-700 bg-slate-800 px-2 py-1 text-sm text-white focus:ring-2 focus:ring-yellow-500 focus:outline-none"
+					>
+						{#each roles as role (role)}
+							<option value={role}>{role}</option>
+						{/each}
+					</select>
 					<input
 						type="date"
 						bind:value={player.startedOn}


### PR DESCRIPTION
## Why

In the team roster editor, a member's role was rendered as **static text** — the only way to change someone's status (active → substitute → former, etc.) was to delete and re-add them. Tedious and error-prone.

## Changes

- Replace `<span>{player.role}</span>` with an inline `<select bind:value={player.role}>` (`TeamPlayerInput.svelte`), using the existing `roles` list and an `aria-label`.

## Verification

- Persistence traced end-to-end: `selectedPlayers` ($bindable) → serialized in `TeamEdit.svelte` → parsed in `+page.server.ts` → `updateTeam` delete-and-reinsert writes `role`. Edited roles on existing members are saved.
- Reactive & mutation-safe in Svelte 5; row still a 5-column grid.
- `svelte-check`: 0 errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)