### PR TITLE
fix(admin): correctness bugs across the panel

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -149,6 +149,7 @@
 	"edit": "Bearbeiten",
 	"delete": "Löschen",
 	"cancel": "Abbrechen",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/en.json
+++ b/messages/en.json
@@ -257,6 +257,7 @@
 	"cancel": "Cancel",
 	"confirm": "Confirm",
 	"confirm_title": "Are you sure?",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"create": "Create",
 	"update": "Update",

--- a/messages/es.json
+++ b/messages/es.json
@@ -155,6 +155,7 @@
 	"edit": "Editar",
 	"delete": "Eliminar",
 	"cancel": "Cancelar",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -154,6 +154,7 @@
 	"edit": "Modifier",
 	"delete": "Supprimer",
 	"cancel": "Annuler",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/id.json
+++ b/messages/id.json
@@ -154,6 +154,7 @@
 	"edit": "Edit",
 	"delete": "Hapus",
 	"cancel": "Batal",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -155,6 +155,7 @@
 	"cancel": "キャンセル",
 	"confirm": "確認",
 	"confirm_title": "よろしいですか？",
+	"confirm_delete_message": "この操作は取り消せません。",
 	"notifications": "通知",
 	"create": "作成",
 	"update": "更新",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -154,6 +154,7 @@
 	"edit": "편집",
 	"delete": "삭제",
 	"cancel": "취소",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -154,6 +154,7 @@
 	"edit": "Editar",
 	"delete": "Deletar",
 	"cancel": "Cancelar",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -148,6 +148,7 @@
 	"edit": "Редактировать",
 	"delete": "Удалить",
 	"cancel": "Отмена",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/uk-ua.json
+++ b/messages/uk-ua.json
@@ -120,6 +120,7 @@
 	"edit": "Редагувати",
 	"delete": "Видалити",
 	"cancel": "Відмінити",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -154,6 +154,7 @@
 	"edit": "Chỉnh sửa",
 	"delete": "Xóa",
 	"cancel": "Hủy bỏ",
+	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",
 	"confirm": "Confirm",

--- a/messages/zh-tw.json
+++ b/messages/zh-tw.json
@@ -154,6 +154,7 @@
 	"edit": "編輯",
 	"delete": "刪除",
 	"cancel": "取消",
+	"confirm_delete_message": "此操作無法撤銷。",
 	"notifications": "通知",
 	"confirm_title": "確定嗎？",
 	"confirm": "確認",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -156,6 +156,7 @@
 	"cancel": "取消",
 	"confirm": "确认",
 	"confirm_title": "确定吗？",
+	"confirm_delete_message": "此操作无法撤销。",
 	"notifications": "通知",
 	"create": "创建",
 	"update": "更新",

--- a/src/routes/(user)/admin/community/TagEdit.svelte
+++ b/src/routes/(user)/admin/community/TagEdit.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import type { CommunityTag } from '$lib/server/db/schemas/about/community';
 	import { m } from '$lib/paraglide/messages';
+	import { toast } from '$lib/stores/toast.svelte';
 
 	let {
 		tag,
@@ -22,9 +23,14 @@
 	method="POST"
 	action="?/tag"
 	use:enhance={() => {
-		return async ({ update }) => {
-			await update();
-			onSuccess();
+		return async ({ result }) => {
+			if (result.type === 'success') {
+				onSuccess();
+			} else if (result.type === 'failure') {
+				toast.error((result.data?.error as string) ?? m.error_occurred());
+			} else if (result.type === 'error') {
+				toast.error(result.error?.message ?? m.error_occurred());
+			}
 		};
 	}}
 	class="flex flex-col gap-4"

--- a/src/routes/(user)/admin/edit-history/+page.svelte
+++ b/src/routes/(user)/admin/edit-history/+page.svelte
@@ -115,8 +115,7 @@
 
 <main class="mx-auto max-w-screen-lg px-4">
 	<div class="mb-6 flex items-center justify-between">
-		<h1 class="text-2xl font-bold">{m.admin_dashboard()}</h1>
-		<h2 class="text-xl font-bold">{m['editing.history.edit_history']()}</h2>
+		<h1 class="text-2xl font-bold">{m['editing.history.edit_history']()}</h1>
 	</div>
 
 	<div class="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/src/routes/(user)/admin/events/+page.svelte
+++ b/src/routes/(user)/admin/events/+page.svelte
@@ -23,8 +23,6 @@
 	let { data }: { data: PageData } = $props();
 	let { events, action, id, organizers, eventOrganizers } = $derived(data);
 
-	$inspect('[admin/events] data', data);
-
 	// Inline status quick-edit on the list (auto-submits ?/updateStatus).
 	const statusOptions = ['upcoming', 'live', 'finished', 'cancelled', 'postponed'];
 	function statusBadgeClass(status: string): string {

--- a/src/routes/(user)/admin/matches/[eventId]/+page.svelte
+++ b/src/routes/(user)/admin/matches/[eventId]/+page.svelte
@@ -25,8 +25,6 @@
 
 	let { data }: PageProps = $props();
 
-	$inspect('[admin/matches] data', data);
-
 	let action:
 		| 'editMatch'
 		| 'editStage'
@@ -399,7 +397,6 @@
 	};
 
 	let editingGame = $state<EditingGame | null>(null);
-	$inspect('[admin/matches] editingGame', editingGame);
 
 	let deletingGame = $state<{ game: any; matchId: string } | null>(null);
 	let isDeletingGame = $state(false);

--- a/src/routes/(user)/admin/matches/[eventId]/GameEdit.svelte
+++ b/src/routes/(user)/admin/matches/[eventId]/GameEdit.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
 	import type { ActionResult } from '@sveltejs/kit';
 	import CharacterSelect from '$lib/components/CharacterSelect.svelte';
 	import AccountIdCombobox from '$lib/components/AccountIdCombobox.svelte';
@@ -658,8 +659,8 @@
 							gameId={data.game.id}
 							vods={data.game.vods || []}
 							onSuccess={() => {
-								// Refresh the page data
-								window.location.reload();
+								// Refresh the page data in place
+								invalidateAll();
 							}}
 						/>
 					</div>

--- a/src/routes/(user)/admin/matches/[eventId]/GameEdit.svelte
+++ b/src/routes/(user)/admin/matches/[eventId]/GameEdit.svelte
@@ -658,9 +658,13 @@
 						<GameVodEdit
 							gameId={data.game.id}
 							vods={data.game.vods || []}
-							onSuccess={() => {
-								// Refresh the page data in place
-								invalidateAll();
+							onSuccess={async () => {
+								// `data` here is the editingGame snapshot built when the modal opened, so
+								// invalidateAll() refreshes the route but NOT this modal's stale vods prop.
+								// Refresh the page data, then close the modal so the change isn't shown
+								// against the old snapshot (which looked like the save had failed).
+								await invalidateAll();
+								onSuccess();
 							}}
 						/>
 					</div>

--- a/src/routes/(user)/admin/matches/[eventId]/GameVodEdit.svelte
+++ b/src/routes/(user)/admin/matches/[eventId]/GameVodEdit.svelte
@@ -7,6 +7,7 @@
 	import IconParkSolidAdd from '~icons/icon-park-solid/add';
 	import { m } from '$lib/paraglide/messages';
 	import { detectPlatform } from '$lib/utils/video';
+	import { confirm } from '$lib/stores/confirm.svelte';
 
 	let {
 		gameId,
@@ -135,6 +136,15 @@
 	}
 
 	async function handleDeleteVod(vod: GameVod) {
+		if (
+			!(await confirm.ask({
+				title: m.delete_vod_title(),
+				message: m.confirm_delete_message(),
+				destructive: true
+			}))
+		) {
+			return;
+		}
 		deletingVod = vod;
 		isDeleting = true;
 		errorMessage = '';

--- a/src/routes/(user)/admin/matches/[eventId]/MatchEdit.svelte
+++ b/src/routes/(user)/admin/matches/[eventId]/MatchEdit.svelte
@@ -134,7 +134,7 @@
 	}
 </script>
 
-<Modal show={true} title={m.edit_match()} onClose={() => {}}>
+<Modal show={true} title={m.edit_match()} onClose={onCancel}>
 	<form
 		method="POST"
 		action={match.id ? '?/update' : '?/create'}
@@ -143,7 +143,7 @@
 				if (result.type === 'success') {
 					onsuccess();
 				} else if (result.type === 'failure') {
-					errorMessage = result.data?.error || m.failed_to_change_password();
+					errorMessage = result.data?.error || m.error_occurred();
 				} else if (result.type === 'error') {
 					errorMessage = result.error?.message || m.error_occurred();
 				}

--- a/src/routes/(user)/admin/players/+page.svelte
+++ b/src/routes/(user)/admin/players/+page.svelte
@@ -702,7 +702,7 @@
 								</button>
 								<button
 									type="button"
-									class="text-gray-600 hover:text-gray-800"
+									class="text-gray-400 hover:text-white"
 									title="View edit history"
 									onclick={() => {
 										selectedPlayer = player;

--- a/src/routes/(user)/admin/players/PlayerEdit.svelte
+++ b/src/routes/(user)/admin/players/PlayerEdit.svelte
@@ -298,7 +298,7 @@
 			if (result.type === 'success') {
 				onsuccess();
 			} else if (result.type === 'failure') {
-				errorMessage = result.data?.error || m.failed_to_change_password();
+				errorMessage = result.data?.error || m.error_occurred();
 			} else if (result.type === 'error') {
 				errorMessage = result.error?.message || m.error_occurred();
 			}

--- a/src/routes/(user)/admin/teams/+page.svelte
+++ b/src/routes/(user)/admin/teams/+page.svelte
@@ -431,7 +431,7 @@
 								</button>
 								<button
 									type="button"
-									class="text-gray-600 hover:text-gray-800"
+									class="text-gray-400 hover:text-white"
 									title="View edit history"
 									onclick={() => {
 										selectedTeam = team;

--- a/src/routes/(user)/admin/users/+page.svelte
+++ b/src/routes/(user)/admin/users/+page.svelte
@@ -5,6 +5,7 @@
 	import { goto } from '$app/navigation';
 	import type { Role } from '$lib/server/db/schema';
 	import { browser } from '$app/environment';
+	import { confirm } from '$lib/stores/confirm.svelte';
 
 	import IconParkSolidShield from '~icons/icon-park-solid/shield';
 	import IconParkSolidDeleteFive from '~icons/icon-park-solid/delete-five';
@@ -81,18 +82,20 @@
 		});
 	}
 
-	function handleDeleteRole(event: SubmitEvent) {
+	async function handleDeleteRole(event: SubmitEvent) {
+		event.preventDefault();
+		const form = event.target as HTMLFormElement;
+		if (
+			!(await confirm.ask({
+				message: m.confirm_delete_message(),
+				destructive: true
+			}))
+		) {
+			return;
+		}
 		errorMessage = '';
 		successMessage = '';
-
-		const form = event.target as HTMLFormElement;
-		enhance(form, () => async ({ update }) => {
-			await update();
-			successMessage = m.role_deleted_successfully();
-			setTimeout(() => {
-				successMessage = '';
-			}, 3000);
-		});
+		form.submit();
 	}
 
 	function startEditRole(role: Role) {
@@ -116,8 +119,7 @@
 
 <main class="mx-auto max-w-screen-lg px-4">
 	<div class="mb-6 flex items-center justify-between">
-		<h1 class="text-2xl font-bold">{m.admin_dashboard()}</h1>
-		<h2 class="text-xl font-bold">{m.users()}</h2>
+		<h1 class="text-2xl font-bold">{m.users()}</h1>
 	</div>
 
 	{#if errorMessage}


### PR DESCRIPTION
PR 2 of the admin overhaul stack. **Base: `admin-infra` (#70)** — review/merge that first.

Objective bug fixes (no refactors):

- **TagEdit false success** — reported success even when the save failed; now handles the action result and toasts errors.
- **Wrong error fallback** — PlayerEdit/MatchEdit showed `failed_to_change_password` as their generic fallback → `error_occurred`.
- **Unguarded destructive deletes** — VOD delete and user-role delete had *zero* confirmation (one click = data loss); both now use the shared `ConfirmDialog`.
- **Full page reload** — GameEdit VOD success did `window.location.reload()` → `invalidateAll()`.
- **Dead close button** — MatchEdit's "✕" was `onClose={() => {}}` → wired to cancel.
- **Broken headers** — users / edit-history `<h1>` said "Admin Dashboard" instead of the section name.
- **Invisible icons** — per-row history icon was `gray-600` on `gray-800` → visible.
- **Debug leftovers** — removed `$inspect()` calls (events, matches).

New i18n key: `confirm_delete_message` (en/zh/ja).

`svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)