### PR TITLE
feat(about): link to successor community projects

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -431,6 +431,11 @@
 		"links_title": "Links",
 		"links_github": "GitHub Repository",
 		"links_discord": "Discord Community",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "und vielen Dank an alle, die Informationen über vergangene und bevorstehende Events bereitgestellt haben, an {idreamsky} (Day1 Studio) für die Erschaffung des Spiels, für das wir leidenschaftlich sind, und an jeden Spieler, der die E-Sport-Szene möglich gemacht hat."
 	},
 	"europe": "Europa (EU)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -567,6 +567,11 @@
 		"links_title": "Links",
 		"links_github": "GitHub Repository",
 		"links_discord": "Discord Community",
+		"alt_projects_title": "Alternative Projects",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_tools": "Tools",
 		"thanks_message": "and thank you to everyone who provided information about past and upcoming events, to {idreamsky} (Day1 Studio) for creating the game we're passionate about, and to every player who made the eSport scene possible."
 	},
 	"europe": "Europe (EU)",

--- a/messages/es.json
+++ b/messages/es.json
@@ -431,6 +431,11 @@
 		"links_title": "Enlaces",
 		"links_github": "Repositorio de GitHub",
 		"links_discord": "Comunidad de Discord",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "y gracias a todos los que proporcionaron información sobre eventos pasados y próximos, a {idreamsky} (Day1 Studio) por crear el juego que nos apasiona, y a todos los jugadores que hicieron posible la escena eSports."
 	},
 	"europe": "Europa (EU)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -431,6 +431,11 @@
 		"links_title": "Liens",
 		"links_github": "Dépôt GitHub",
 		"links_discord": "Communauté Discord",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "et merci à tous ceux qui ont fourni des informations sur les événements passés et à venir, à {idreamsky} (Day1 Studio) pour avoir créé le jeu dont nous sommes passionnés, et à tous les joueurs qui ont rendu la scène eSport possible."
 	},
 	"europe": "Europe (EU)",

--- a/messages/id.json
+++ b/messages/id.json
@@ -431,6 +431,11 @@
 		"links_title": "Tautan",
 		"links_github": "Repositori GitHub",
 		"links_discord": "Komunitas Discord",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "dan terima kasih kepada semua yang telah memberikan informasi tentang acara masa lalu dan mendatang, kepada {idreamsky} (Day1 Studio) karena telah menciptakan permainan yang kami sukai, dan kepada semua pemain yang telah membuat adegan eSports menjadi mungkin."
 	},
 	"europe": "Eropa (EU)",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -368,6 +368,11 @@
 		"links_title": "リンク",
 		"links_github": "GitHubリポジトリ",
 		"links_discord": "Discordコミュニティ",
+		"alt_projects_title": "関連プロジェクト",
+		"alt_projects_description": "LemonTVのビジョンが情熱ある独立したコミュニティプロジェクトに受け継がれていることを嬉しく思います：",
+		"alt_projects_esports": "eスポーツ",
+		"alt_projects_utilities": "ユーティリティ",
+		"alt_projects_tools": "ツール",
 		"thanks_message": "過去および今後のイベントに関する情報を提供してくださったすべての方々、私たちが情熱を注ぐゲームを作成してくださった{idreamsky}（Day1 Studio）に、そしてeスポーツシーンを可能にしたすべてのプレイヤーに感謝いたします。"
 	},
 	"europe": "ヨーロッパ (EU)",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -431,6 +431,11 @@
 		"links_title": "링크",
 		"links_github": "GitHub 저장소",
 		"links_discord": "Discord 커뮤니티",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "과거 및 예정된 이벤트에 대한 정보를 제공해 주신 모든 분들, 우리가 열정을 가진 게임을 만들어 주신 {idreamsky} (Day1 Studio)에, 그리고 e스포츠 씬을 가능하게 한 모든 플레이어에게 감사드립니다."
 	},
 	"europe": "유럽 (EU)",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -431,6 +431,11 @@
 		"links_title": "Links",
 		"links_github": "Repositório GitHub",
 		"links_discord": "Comunidade Discord",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "e obrigado a todos que forneceram informações sobre eventos passados e futuros, a {idreamsky} (Day1 Studio) por criar o jogo que nos apaixona, e a todos os jogadores que tornaram possível a cena eSports."
 	},
 	"europe": "Europa (EU)",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -431,6 +431,11 @@
 		"links_title": "Ссылки",
 		"links_github": "GitHub репозиторий",
 		"links_discord": "Discord сообщество",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "и спасибо всем, кто предоставил информацию о прошлых и предстоящих событиях, {idreamsky} (Day1 Studio) за создание игры, которой мы увлечены, и всем игрокам, которые сделали возможной eSports сцену."
 	},
 	"europe": "Европа (EU)",

--- a/messages/uk-ua.json
+++ b/messages/uk-ua.json
@@ -431,6 +431,11 @@
 		"links_title": "Посилання",
 		"links_github": "GitHub репозиторій",
 		"links_discord": "Discord спільнота",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "і дякуємо всім, хто надав інформацію про минулі та майбутні події, {idreamsky} (Day1 Studio) за створення гри, якою ми захоплені, та всім гравцям, які зробили можливою eSports сцену."
 	},
 	"europe": "Європа (EU)",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -431,6 +431,11 @@
 		"links_title": "Liên kết",
 		"links_github": "Kho lưu trữ GitHub",
 		"links_discord": "Cộng đồng Discord",
+		"alt_projects_tools": "Tools",
+		"alt_projects_utilities": "Utilities",
+		"alt_projects_esports": "eSports coverage",
+		"alt_projects_description": "We're glad LemonTV's vision is being carried forward by independent, passionate community projects:",
+		"alt_projects_title": "Alternative Projects",
 		"thanks_message": "và cảm ơn tất cả những người đã cung cấp thông tin về các sự kiện trong quá khứ và sắp tới, {idreamsky} (Day1 Studio) đã tạo ra trò chơi mà chúng tôi đam mê, và tất cả người chơi đã làm cho cảnh eSports trở nên khả thi."
 	},
 	"europe": "Châu Âu (EU)",

--- a/messages/zh-tw.json
+++ b/messages/zh-tw.json
@@ -431,6 +431,11 @@
 		"links_title": "我們的鏈接",
 		"links_github": "GitHub",
 		"links_discord": "Discord",
+		"alt_projects_tools": "工具",
+		"alt_projects_utilities": "實用工具",
+		"alt_projects_esports": "電競內容",
+		"alt_projects_description": "很高興 LemonTV 的願景正由充滿熱情的獨立社群專案繼續傳承：",
+		"alt_projects_title": "其他專案",
 		"thanks_message": "感謝為我們提供所有賽事信息的卡拉彼丘玩家們，感謝 {idreamsky} (Day1工作室) 創造了我們所熱愛的遊戲，感謝讓卡拉彼丘丘電競夢想成真的玩家們喵～<br /><p class=\"text-center text-xl\">祝願每一位為電競夢而努力的卡丘人心想事成喵！</p>"
 	},
 	"europe": "歐洲 (EU)",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -432,6 +432,11 @@
 		"links_title": "我们的链接",
 		"links_github": "GitHub",
 		"links_discord": "Discord",
+		"alt_projects_title": "其他项目",
+		"alt_projects_description": "很高兴 LemonTV 的愿景正由充满热情的独立社区项目继续传承：",
+		"alt_projects_esports": "电竞内容",
+		"alt_projects_utilities": "实用工具",
+		"alt_projects_tools": "工具",
 		"thanks_message": "感谢为我们提供所有赛事信息的卡拉彼丘玩家们，感谢 {idreamsky} (Day1工作室) 创造了我们所热爱的游戏，感谢让卡拉彼丘丘电竞梦想成真的玩家们喵～<br /><p class=\"text-center text-xl\">祝愿每一位为电竞梦而努力的卡丘人心想事成喵！</p>"
 	},
 	"europe": "欧洲 (EU)",

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -13,3 +13,8 @@ export const GITHUB_REPO_URL = 'https://github.com/LemonTV-win/LemonTV';
 
 /** Branded fallback banner shown for events that have no image. */
 export const EVENT_PLACEHOLDER_IMAGE = '/event-placeholder.svg';
+
+// Independent community projects carrying LemonTV's vision forward.
+export const STRINOVAHUB_URL = 'https://strinovahub.com/';
+export const STRINGIFY_URL = 'https://stringify.gg/';
+export const STRINOPLANT_URL = 'https://sunguraa.github.io/StrinoPlant/';

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -17,7 +17,10 @@
 		IDREAMSKY_URL_ZH,
 		STRINOVA_ESPORTS_HUB_DISCORD_URL,
 		LEMON_TV_QQ_URL,
-		GITHUB_REPO_URL
+		GITHUB_REPO_URL,
+		STRINOVAHUB_URL,
+		STRINGIFY_URL,
+		STRINOPLANT_URL
 	} from '$lib/consts';
 	import { getLocale } from '$lib/paraglide/runtime';
 	import placeholderAvatar from '$assets/placeholder_avatar.png';
@@ -42,6 +45,27 @@
 		bilibili: IconBilibili,
 		homepage: IconHome
 	};
+
+	const ALT_PROJECTS: { name: string; url: string; focus: () => string; maintainer: string }[] = [
+		{
+			name: 'StrinovaHub',
+			url: STRINOVAHUB_URL,
+			focus: () => m['about.alt_projects_esports'](),
+			maintainer: 'MeowDev (#savepleco)'
+		},
+		{
+			name: 'Stringify',
+			url: STRINGIFY_URL,
+			focus: () => m['about.alt_projects_utilities'](),
+			maintainer: 'mini.soap'
+		},
+		{
+			name: 'StrinoPlant',
+			url: STRINOPLANT_URL,
+			focus: () => m['about.alt_projects_tools'](),
+			maintainer: 'sunguraa'
+		}
+	];
 </script>
 
 <svelte:head>
@@ -213,6 +237,30 @@
 						<IconGithub class="h-6 w-6" />
 						{m['about.links_github']()}
 					</a>
+				</div>
+			</section>
+
+			<section class="my-12 text-center">
+				<h2 class="mb-4 text-3xl font-semibold">{m['about.alt_projects_title']()}</h2>
+				<p class="mx-auto mb-8 max-w-2xl text-slate-300">
+					{m['about.alt_projects_description']()}
+				</p>
+				<div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+					{#each ALT_PROJECTS as project (project.url)}
+						<a
+							href={project.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="glass-card group flex flex-col items-center gap-2 p-6 transition-all duration-300 hover:scale-105"
+						>
+							<h3 class="flex items-center gap-2 text-xl font-semibold text-blue-400 group-hover:text-blue-300">
+								<IconGlobe class="h-5 w-5" />
+								{project.name}
+							</h3>
+							<p class="text-sm font-medium text-slate-200">{project.focus()}</p>
+							<p class="text-xs text-slate-400">{project.maintainer}</p>
+						</a>
+					{/each}
 				</div>
 			</section>
 


### PR DESCRIPTION
Independent of the admin overhaul stack (based on `main`).

Adds an **Alternative Projects** section to the `/about` page celebrating the independent community projects carrying LemonTV's vision forward:

- **StrinovaHub** (eSports) — https://strinovahub.com/ — MeowDev (#savepleco)
- **Stringify** (utilities) — https://stringify.gg/ — mini.soap
- **StrinoPlant** (tools) — https://sunguraa.github.io/StrinoPlant/ — sunguraa

URLs are centralized in `consts.ts`; the section title/intro/category labels are localized (en/zh/ja; other locales fall back to English). External links open in a new tab with `rel="noopener noreferrer"`.

`svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)