### PR TITLE
feat(admin): responsive nav, dashboard metrics, standardized page gating

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -149,6 +149,8 @@
 	"edit": "Bearbeiten",
 	"delete": "Löschen",
 	"cancel": "Abbrechen",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/en.json
+++ b/messages/en.json
@@ -255,6 +255,8 @@
 	"edit": "Edit",
 	"delete": "Delete",
 	"cancel": "Cancel",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm": "Confirm",
 	"confirm_title": "Are you sure?",
 	"confirm_delete_message": "This action cannot be undone.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -155,6 +155,8 @@
 	"edit": "Editar",
 	"delete": "Eliminar",
 	"cancel": "Cancelar",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -154,6 +154,8 @@
 	"edit": "Modifier",
 	"delete": "Supprimer",
 	"cancel": "Annuler",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/id.json
+++ b/messages/id.json
@@ -154,6 +154,8 @@
 	"edit": "Edit",
 	"delete": "Hapus",
 	"cancel": "Batal",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -153,6 +153,8 @@
 	"edit": "編集",
 	"delete": "削除",
 	"cancel": "キャンセル",
+	"open_menu": "メニューを開く",
+	"toggle_sidebar": "サイドバーを切り替え",
 	"confirm": "確認",
 	"confirm_title": "よろしいですか？",
 	"confirm_delete_message": "この操作は取り消せません。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -154,6 +154,8 @@
 	"edit": "편집",
 	"delete": "삭제",
 	"cancel": "취소",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -154,6 +154,8 @@
 	"edit": "Editar",
 	"delete": "Deletar",
 	"cancel": "Cancelar",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -148,6 +148,8 @@
 	"edit": "Редактировать",
 	"delete": "Удалить",
 	"cancel": "Отмена",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/uk-ua.json
+++ b/messages/uk-ua.json
@@ -120,6 +120,8 @@
 	"edit": "Редагувати",
 	"delete": "Видалити",
 	"cancel": "Відмінити",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -154,6 +154,8 @@
 	"edit": "Chỉnh sửa",
 	"delete": "Xóa",
 	"cancel": "Hủy bỏ",
+	"open_menu": "Open menu",
+	"toggle_sidebar": "Toggle sidebar",
 	"confirm_delete_message": "This action cannot be undone.",
 	"notifications": "Notifications",
 	"confirm_title": "Are you sure?",

--- a/messages/zh-tw.json
+++ b/messages/zh-tw.json
@@ -154,6 +154,8 @@
 	"edit": "編輯",
 	"delete": "刪除",
 	"cancel": "取消",
+	"open_menu": "開啟選單",
+	"toggle_sidebar": "切換側邊欄",
 	"confirm_delete_message": "此操作無法撤銷。",
 	"notifications": "通知",
 	"confirm_title": "確定嗎？",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -154,6 +154,8 @@
 	"edit": "编辑",
 	"delete": "删除",
 	"cancel": "取消",
+	"open_menu": "打开菜单",
+	"toggle_sidebar": "切换侧边栏",
 	"confirm": "确认",
 	"confirm_title": "确定吗？",
 	"confirm_delete_message": "此操作无法撤销。",

--- a/src/lib/server/security/permission.ts
+++ b/src/lib/server/security/permission.ts
@@ -1,4 +1,26 @@
+import { redirect } from '@sveltejs/kit';
 import type { UserRole } from '$lib/data/user';
+
+/**
+ * Gate a page `load` by role. Use in admin `+page.server.ts` load functions.
+ *
+ * - Not signed in → redirect to /login (preserving the target for post-login return).
+ * - Signed in but missing the role → redirect to /admin (the dashboard), which is
+ *   consistent across all admin pages instead of each one choosing its own target.
+ */
+export function requirePageRole(
+	event: { locals: App.Locals; url: URL },
+	requiredRoles: UserRole[]
+): void {
+	const user = event.locals.user;
+	if (!user) {
+		const target = event.url.pathname + event.url.search;
+		throw redirect(302, `/login?redirect=${encodeURIComponent(target)}`);
+	}
+	if (!requiredRoles.some((role) => user.roles.includes(role))) {
+		throw redirect(302, '/admin');
+	}
+}
 
 export type PermissionResult =
 	| { status: 'success'; userId: string }

--- a/src/routes/(user)/admin/+layout.svelte
+++ b/src/routes/(user)/admin/+layout.svelte
@@ -3,104 +3,130 @@
 	import { page } from '$app/state';
 	import { m } from '$lib/paraglide/messages';
 
-	import IconParkSolidHome from '~icons/icon-park-solid/home';
-	import IconParkSolidUser from '~icons/icon-park-solid/user';
-	import IconParkSolidPeople from '~icons/icon-park-solid/people';
-	import IconParkSolidEveryUser from '~icons/icon-park-solid/every-user';
 	import IconParkSolidShield from '~icons/icon-park-solid/shield';
-	import IconParkSolidHistory from '~icons/icon-park-solid/history-query';
-	import IconParkSolidCalendar from '~icons/icon-park-solid/calendar';
-	import IconParkSolidTrophy from '~icons/icon-park-solid/trophy';
-	import IconParkSolidGame from '~icons/icon-park-solid/game';
-	import IconParkSolidMessage from '~icons/icon-park-solid/message';
+	import MaterialSymbolsMenuRounded from '~icons/material-symbols/menu-rounded';
+	import MaterialSymbolsCloseRounded from '~icons/material-symbols/close-rounded';
+	import MaterialSymbolsChevronLeftRounded from '~icons/material-symbols/chevron-left-rounded';
 
-	import type { Component } from 'svelte';
 	import Toaster from '$lib/components/Toaster.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import { adminHome, adminSections, visibleSections, type AdminSection } from './sections';
 
 	let { children, data }: LayoutProps = $props();
 	let isExpanded = $state(true);
+	let mobileOpen = $state(false);
 
-	function togglePanel() {
-		isExpanded = !isExpanded;
+	let sections = $derived<AdminSection[]>([
+		adminHome,
+		...visibleSections(adminSections, data.user?.roles)
+	]);
+
+	function isActive(href: string): boolean {
+		const path = page.url.pathname;
+		if (href === '/admin') return path === '/admin';
+		return path === href || path.startsWith(href + '/');
 	}
 </script>
 
-{#snippet tab(href: string, Icon: Component, label: string)}
+{#snippet tab(section: AdminSection, expanded: boolean)}
+	{@const Icon = section.icon}
 	<a
-		class="flex items-center rounded-lg transition-all duration-300 {isExpanded
-			? 'gap-2 px-4 py-2'
-			: 'h-12 w-12 justify-center'} text-lg font-medium text-gray-300 hover:bg-gray-800 hover:text-white {page
-			.url.pathname === href
-			? 'bg-gray-800 text-white'
-			: ''} {!isExpanded ? 'text-center text-base' : ''}"
-		{href}
+		href={section.href}
+		onclick={() => (mobileOpen = false)}
+		aria-current={isActive(section.href) ? 'page' : undefined}
+		class="flex items-center rounded-lg font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-white {expanded
+			? 'gap-2 px-4 py-2 text-lg'
+			: 'h-12 w-12 justify-center'} {isActive(section.href) ? 'bg-gray-800 text-white' : ''}"
 	>
 		<div class="flex w-7 flex-shrink-0 justify-center">
 			<Icon class="h-7 w-7" />
 		</div>
-		<span
-			class="overflow-hidden whitespace-nowrap transition-all duration-300 {isExpanded
-				? 'ml-2 w-auto opacity-100'
-				: 'ml-0 w-0 opacity-0'}">{label}</span
-		>
+		{#if expanded}
+			<span class="overflow-hidden whitespace-nowrap">{section.label()}</span>
+		{/if}
 	</a>
 {/snippet}
 
+{#snippet brand(expanded: boolean)}
+	<span class="flex items-center gap-2 text-white">
+		<IconParkSolidShield class="h-7 w-7 flex-shrink-0" />
+		{#if expanded}<span class="text-xl font-bold whitespace-nowrap">{m.admin_panel()}</span>{/if}
+	</span>
+{/snippet}
+
 <div
-	class="grid h-screen transition-[grid-template-columns] duration-300 {isExpanded
-		? 'grid-cols-[280px_1fr]'
-		: 'grid-cols-[80px_1fr]'}"
+	class="flex h-screen flex-col lg:grid lg:transition-[grid-template-columns] lg:duration-300 {isExpanded
+		? 'lg:grid-cols-[280px_1fr]'
+		: 'lg:grid-cols-[80px_1fr]'}"
 >
+	<!-- Desktop sidebar -->
 	<nav
-		class="relative flex flex-col gap-4 border-r border-gray-800 bg-gray-900/50 p-6 transition-all duration-300 {!isExpanded
-			? 'items-center px-2'
+		class="relative hidden flex-col gap-2 overflow-y-auto border-r border-gray-800 bg-gray-900/50 p-4 lg:flex {!isExpanded
+			? 'items-center'
 			: ''}"
 	>
-		<div class="mb-6 flex flex-col items-center">
-			<h1 class="flex items-center justify-center text-2xl font-bold text-white">
-				<IconParkSolidShield class="h-7 w-7 text-white" />
-				<span
-					class="overflow-hidden whitespace-nowrap transition-all duration-300 {isExpanded
-						? 'ml-4 w-auto opacity-100'
-						: 'ml-0 w-0 opacity-0'} text-xl font-bold text-white"
-				>
-					{m.admin_panel()}
-				</span>
-			</h1>
-		</div>
+		<div class="mb-6 flex justify-center">{@render brand(isExpanded)}</div>
 		<button
-			class="absolute top-12 -right-4 rounded-full bg-gray-800 p-1 text-white hover:bg-gray-700"
-			onclick={togglePanel}
-			aria-label={isExpanded ? 'Collapse panel' : 'Expand panel'}
+			class="absolute top-10 -right-4 z-10 rounded-full bg-gray-800 p-1 text-white hover:bg-gray-700"
+			onclick={() => (isExpanded = !isExpanded)}
+			aria-label={m.toggle_sidebar()}
+			title={m.toggle_sidebar()}
 		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
+			<MaterialSymbolsChevronLeftRounded
 				class="h-6 w-6 transition-transform duration-300 {isExpanded ? '' : 'rotate-180'}"
-				viewBox="0 0 20 20"
-				fill="currentColor"
-			>
-				<path
-					fill-rule="evenodd"
-					d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-					clip-rule="evenodd"
-				/>
-			</svg>
+			/>
 		</button>
-
-		{@render tab('/admin', IconParkSolidHome, m.home())}
-		{#if data.user?.roles.includes('admin')}
-			{@render tab('/admin/users', IconParkSolidUser, m.users())}
-		{/if}
-		{@render tab('/admin/players', IconParkSolidPeople, m.players())}
-		{@render tab('/admin/teams', IconParkSolidEveryUser, m.teams())}
-		{@render tab('/admin/events', IconParkSolidCalendar, m.events())}
-		{@render tab('/admin/matches', IconParkSolidGame, m.matches())}
-		{@render tab('/admin/organizers', IconParkSolidTrophy, m.organizers())}
-		{@render tab('/admin/community', IconParkSolidMessage, m.community())}
-		{@render tab('/admin/edit-history', IconParkSolidHistory, m['editing.history.edit_history']())}
+		{#each sections as section (section.href)}
+			{@render tab(section, isExpanded)}
+		{/each}
 	</nav>
-	<main class="styled-scrollbar overflow-auto p-8">
+
+	<!-- Mobile top bar -->
+	<header
+		class="flex items-center gap-3 border-b border-gray-800 bg-gray-900/50 p-3 lg:hidden"
+	>
+		<button
+			onclick={() => (mobileOpen = true)}
+			aria-label={m.open_menu()}
+			title={m.open_menu()}
+			class="rounded-lg p-1 text-gray-300 hover:bg-gray-800 hover:text-white"
+		>
+			<MaterialSymbolsMenuRounded class="h-6 w-6" />
+		</button>
+		{@render brand(true)}
+	</header>
+
+	<!-- Mobile drawer -->
+	{#if mobileOpen}
+		<div class="fixed inset-0 z-50 lg:hidden">
+			<button
+				class="absolute inset-0 bg-black/50"
+				onclick={() => (mobileOpen = false)}
+				aria-label={m.close()}
+				tabindex="-1"
+			></button>
+			<nav
+				class="absolute top-0 left-0 flex h-full w-72 flex-col gap-2 overflow-y-auto border-r border-gray-800 bg-gray-900 p-4"
+			>
+				<div class="mb-4 flex items-center justify-between">
+					{@render brand(true)}
+					<button
+						onclick={() => (mobileOpen = false)}
+						aria-label={m.close()}
+						title={m.close()}
+						class="rounded-lg p-1 text-gray-300 hover:bg-gray-800 hover:text-white"
+					>
+						<MaterialSymbolsCloseRounded class="h-6 w-6" />
+					</button>
+				</div>
+				{#each sections as section (section.href)}
+					{@render tab(section, true)}
+				{/each}
+			</nav>
+		</div>
+	{/if}
+
+	<main class="styled-scrollbar flex-1 overflow-auto p-4 lg:p-8">
 		{@render children()}
 	</main>
 </div>

--- a/src/routes/(user)/admin/+page.server.ts
+++ b/src/routes/(user)/admin/+page.server.ts
@@ -1,0 +1,26 @@
+import type { PageServerLoad } from './$types';
+import { db } from '$lib/server/db';
+import { count } from 'drizzle-orm';
+import { player, team, event, organizer, match, deletedRecord } from '$lib/server/db/schema';
+
+type FromArg = Parameters<ReturnType<typeof db.select>['from']>[0];
+
+async function tableCount(table: FromArg): Promise<number> {
+	const [row] = await db.select({ value: count() }).from(table);
+	return row?.value ?? 0;
+}
+
+export const load: PageServerLoad = async () => {
+	const [players, teams, events, organizers, matches, trashed] = await Promise.all([
+		tableCount(player),
+		tableCount(team),
+		tableCount(event),
+		tableCount(organizer),
+		tableCount(match),
+		tableCount(deletedRecord)
+	]);
+
+	return {
+		stats: { players, teams, events, organizers, matches, trashed }
+	};
+};

--- a/src/routes/(user)/admin/+page.svelte
+++ b/src/routes/(user)/admin/+page.svelte
@@ -1,19 +1,33 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
-	import IconParkSolidUser from '~icons/icon-park-solid/user';
-	import IconParkSolidPeople from '~icons/icon-park-solid/people';
-	import IconParkSolidSetting from '~icons/icon-park-solid/setting';
-	import IconParkSolidEveryUser from '~icons/icon-park-solid/every-user';
-	import IconParkSolidCalendar from '~icons/icon-park-solid/calendar';
-	import IconParkSolidHistory from '~icons/icon-park-solid/history-query';
-	import IconParkSolidTrophy from '~icons/icon-park-solid/trophy';
-	import IconParkSolidGame from '~icons/icon-park-solid/game';
-	import IconParkSolidMessage from '~icons/icon-park-solid/message';
-	import IconParkSolidDelete from '~icons/icon-park-solid/delete';
-	import IconParkSolidKey from '~icons/icon-park-solid/key';
 	import type { Component } from 'svelte';
 	import type { PageData } from './$types';
+	import { adminSections, visibleSections, type AdminCardColor } from './sections';
+
 	let { data }: { data: PageData } = $props();
+
+	let sections = $derived(visibleSections(adminSections, data.user?.roles).filter((s) => s.card));
+
+	const cardColorClasses: Record<AdminCardColor, string> = {
+		blue: 'text-blue-400 group-hover:text-blue-300',
+		green: 'text-green-400 group-hover:text-green-300',
+		red: 'text-red-400 group-hover:text-red-300',
+		purple: 'text-purple-400 group-hover:text-purple-300',
+		yellow: 'text-yellow-400 group-hover:text-yellow-300'
+	};
+
+	let stats = $derived(
+		data.stats
+			? [
+					{ label: m.players(), value: data.stats.players, href: '/admin/players' },
+					{ label: m.teams(), value: data.stats.teams, href: '/admin/teams' },
+					{ label: m.events(), value: data.stats.events, href: '/admin/events' },
+					{ label: m.matches(), value: data.stats.matches, href: '/admin/matches' },
+					{ label: m.organizers(), value: data.stats.organizers, href: '/admin/organizers' },
+					{ label: m.trash_title(), value: data.stats.trashed, href: '/admin/trash' }
+				]
+			: []
+	);
 </script>
 
 {#snippet adminCard(
@@ -21,25 +35,15 @@
 	Icon: Component,
 	title: string,
 	description: string,
-	color: 'blue' | 'green' | 'red' | 'purple' | 'yellow'
+	color: AdminCardColor
 )}
 	<a
 		{href}
-		class="group flex flex-col items-center rounded-xl bg-gray-800/70 p-6 shadow transition-colors hover:bg-gray-700"
+		class="group flex flex-col items-center rounded-xl bg-gray-800/70 p-6 text-center shadow transition-colors hover:bg-gray-700"
 	>
-		<Icon
-			class="mb-3 h-10 w-10 transition-colors {color === 'blue'
-				? 'text-blue-400 group-hover:text-blue-300'
-				: color === 'green'
-					? 'text-green-400 group-hover:text-green-300'
-					: color === 'red'
-						? 'text-red-400 group-hover:text-red-300'
-						: color === 'purple'
-							? 'text-purple-400 group-hover:text-purple-300'
-							: 'text-yellow-400 group-hover:text-yellow-300'}"
-		/>
+		<Icon class="mb-3 h-10 w-10 transition-colors {cardColorClasses[color]}" />
 		<span class="mb-1 text-xl font-semibold text-white">{title}</span>
-		<span class="text-center text-sm text-gray-400">{description}</span>
+		<span class="text-sm text-gray-400">{description}</span>
 	</a>
 {/snippet}
 
@@ -48,88 +52,28 @@
 	<p class="text-lg text-gray-400">{m.welcome_admin()}</p>
 </div>
 
+{#if stats.length > 0}
+	<div class="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+		{#each stats as stat (stat.href)}
+			<a
+				href={stat.href}
+				class="flex flex-col items-center rounded-xl bg-gray-800/70 p-4 shadow transition-colors hover:bg-gray-700"
+			>
+				<span class="text-2xl font-bold text-white">{stat.value}</span>
+				<span class="text-center text-xs text-gray-400">{stat.label}</span>
+			</a>
+		{/each}
+	</div>
+{/if}
+
 <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-	{#if data.user?.roles.includes('admin')}
+	{#each sections as section (section.href)}
 		{@render adminCard(
-			'/admin/users',
-			IconParkSolidUser,
-			m.users(),
-			m.admin_users_desc ? m.admin_users_desc() : 'Manage all users, roles, and permissions.',
-			'blue'
+			section.href,
+			section.icon,
+			section.label(),
+			section.description?.() ?? '',
+			section.color ?? 'blue'
 		)}
-	{/if}
-	{@render adminCard(
-		'/admin/players',
-		IconParkSolidPeople,
-		m.players(),
-		m.admin_players_desc(),
-		'green'
-	)}
-	{@render adminCard(
-		'/admin/teams',
-		IconParkSolidEveryUser,
-		m.teams(),
-		m.admin_teams_desc(),
-		'red'
-	)}
-	{@render adminCard(
-		'/admin/events',
-		IconParkSolidCalendar,
-		m.events(),
-		m.admin_events_desc(),
-		'purple'
-	)}
-	{@render adminCard(
-		'/admin/matches',
-		IconParkSolidGame,
-		m.matches(),
-		m.admin_matches_desc(),
-		'blue'
-	)}
-	{@render adminCard(
-		'/admin/organizers',
-		IconParkSolidTrophy,
-		m.organizers(),
-		m.admin_organizers_desc(),
-		'yellow'
-	)}
-	{@render adminCard(
-		'/admin/community',
-		IconParkSolidMessage,
-		m.community(),
-		m.admin_community_desc(),
-		'purple'
-	)}
-	{@render adminCard(
-		'/admin/edit-history',
-		IconParkSolidHistory,
-		m['editing.history.edit_history'](),
-		m['editing.history.edit_history_desc'](),
-		'yellow'
-	)}
-	{@render adminCard(
-		'/admin/trash',
-		IconParkSolidDelete,
-		m.trash_title(),
-		m.trash_card_desc(),
-		'red'
-	)}
-	{#if data.user?.roles.includes('admin')}
-		{@render adminCard(
-			'/admin/mcp-log',
-			IconParkSolidKey,
-			m.mcp_log_title(),
-			m.mcp_log_card_desc(),
-			'green'
-		)}
-	{/if}
-	{#if data.user?.roles.includes('admin')}
-		{@render adminCard(
-			'/admin/settings',
-			IconParkSolidSetting,
-			m.settings ? m.settings() : 'Settings',
-			m.admin_settings_desc(),
-			'yellow'
-		)}
-	{/if}
+	{/each}
 </div>

--- a/src/routes/(user)/admin/+page.ts
+++ b/src/routes/(user)/admin/+page.ts
@@ -2,8 +2,9 @@ import { m } from '$lib/paraglide/messages';
 import type { PageMetadata } from '$lib/seo';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async () => {
+export const load: PageLoad = async ({ data }) => {
 	return {
+		...data,
 		metadata: {
 			title: `${m.admin_panel()} | LemonTV`,
 			description: m.welcome_admin()

--- a/src/routes/(user)/admin/community/+page.server.ts
+++ b/src/routes/(user)/admin/community/+page.server.ts
@@ -1,4 +1,4 @@
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 import {
 	getDiscordServers,
 	createDiscordServer,
@@ -15,18 +15,10 @@ import {
 import { randomUUID } from 'node:crypto';
 import type { PageServerLoad, Actions } from './$types';
 import type { DiscordServer, CommunityTag } from '$lib/server/db/schemas/about/community';
-import { checkPermissions } from '$lib/server/security/permission';
+import { checkPermissions, requirePageRole } from '$lib/server/security/permission';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
-	const user = locals.user;
-	if (!user?.roles) {
-		const fullUrl = url.pathname + url.search;
-		throw redirect(302, `/login?redirect=${encodeURIComponent(fullUrl)}`);
-	}
-
-	if (!['admin', 'editor'].some((role) => user.roles.includes(role))) {
-		throw redirect(302, '/');
-	}
+	requirePageRole({ locals, url }, ['admin', 'editor']);
 
 	return {
 		discordServers: await getDiscordServers(),

--- a/src/routes/(user)/admin/edit-history/+page.server.ts
+++ b/src/routes/(user)/admin/edit-history/+page.server.ts
@@ -3,8 +3,11 @@ import { db } from '$lib/server/db';
 import { editHistory } from '$lib/server/db/schemas/edit-history';
 import { user } from '$lib/server/db/schemas/auth/user';
 import { eq, and, like, desc } from 'drizzle-orm';
+import { requirePageRole } from '$lib/server/security/permission';
 
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
+	requirePageRole({ locals, url }, ['admin', 'editor']);
+
 	const tableName = url.searchParams.get('tableName');
 	const recordId = url.searchParams.get('recordId');
 	const fieldName = url.searchParams.get('fieldName');
@@ -32,8 +35,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			editHistory,
 			editor: {
 				id: user.id,
-				username: user.username,
-				email: user.email
+				username: user.username
 			}
 		})
 		.from(editHistory)
@@ -57,8 +59,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	const users = await db
 		.select({
 			id: user.id,
-			username: user.username,
-			email: user.email
+			username: user.username
 		})
 		.from(user);
 

--- a/src/routes/(user)/admin/mcp-log/+page.server.ts
+++ b/src/routes/(user)/admin/mcp-log/+page.server.ts
@@ -1,10 +1,10 @@
-import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { db } from '$lib/server/db';
 import { mcpAuditLog } from '$lib/server/db/schemas/auth/mcp-audit-log';
 import { mcpToken } from '$lib/server/db/schemas/auth/mcp-token';
 import { user } from '$lib/server/db/schemas/auth/user';
 import { count, desc, eq } from 'drizzle-orm';
+import { requirePageRole } from '$lib/server/security/permission';
 
 const PAGE_SIZE = 50;
 const STATUSES = ['success', 'denied', 'error', 'rate_limited'] as const;
@@ -12,9 +12,7 @@ type Status = (typeof STATUSES)[number];
 
 export const load: PageServerLoad = async ({ locals, url }) => {
 	// Moderation view — shows every editor's token activity and IPs, so admin only.
-	if (!locals.user || !locals.user.roles.includes('admin')) {
-		throw redirect(302, '/admin');
-	}
+	requirePageRole({ locals, url }, ['admin']);
 
 	const statusParam = url.searchParams.get('status');
 	const status: Status | undefined = STATUSES.includes(statusParam as Status)

--- a/src/routes/(user)/admin/users/+page.server.ts
+++ b/src/routes/(user)/admin/users/+page.server.ts
@@ -1,15 +1,12 @@
-import { fail, redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { db } from '$lib/server/db';
 import * as table from '$lib/server/db/schema';
 import { and, eq } from 'drizzle-orm';
-import { checkPermissions } from '$lib/server/security/permission';
+import { checkPermissions, requirePageRole } from '$lib/server/security/permission';
 
 export const load: PageServerLoad = async (event) => {
-	if (!event.locals.user || !event.locals.user.roles.includes('admin')) {
-		const fullUrl = event.url.pathname + event.url.search;
-		throw redirect(302, `/login?redirect=${encodeURIComponent(fullUrl)}`);
-	}
+	requirePageRole(event, ['admin']);
 
 	const users = await db.select().from(table.user);
 	const roles = await db.select().from(table.role);


### PR DESCRIPTION
PR 3 of the admin overhaul stack. **Base: `admin-bugs` (#71).**

### Navigation (`+layout.svelte`)
- Sidebar now driven by the shared `adminSections` config — **Trash and MCP-Log are no longer orphaned** once you navigate into a section.
- **Responsive**: collapsible sidebar on desktop, hamburger + slide-over drawer below `lg` (there was no mobile nav before).
- Active tab now matches sub-routes (`startsWith`) and sets `aria-current`.
- Localized `toggle_sidebar` / `open_menu` aria-labels (all 13 locales).

### Dashboard (`+page.svelte` / `+page.ts` / new `+page.server.ts`)
- Cards derived from `adminSections` — **removes the dead `/admin/settings` card that 404'd**.
- Adds a metrics strip (players / teams / events / matches / organizers / trash counts).

### Permission gating
- New shared `requirePageRole()` load helper → consistent redirects (unauth → `/login?redirect`, wrong role → `/admin`), applied to users, mcp-log, community, edit-history (the latter had **no** page-level check).
- **Security:** edit-history no longer ships every user's email to editors (removed from both queries; the page never used it).

Deferred to a later PR: admin breadcrumbs.

`svelte-check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)