### PR TITLE
fix(admin): paraglide message calls in PlayerRadarGraph + minor cleanup

### DIFF
--- a/src/lib/components/PlayerRadarGraph.svelte
+++ b/src/lib/components/PlayerRadarGraph.svelte
@@ -77,24 +77,24 @@
 	}
 
 	let metricText = $derived({
-		winRate: m['content.stats.metrics.win_rate'],
-		kdRatio: m['content.stats.metrics.kd_ratio'],
-		killsPerGame: m['content.stats.metrics.kills_per_game'],
-		deathsPerGame: m['content.stats.metrics.deaths_per_game'],
-		survivalRate: m['content.stats.metrics.survival_rate'],
-		assistsPerGame: m['content.stats.metrics.assists_per_game'],
-		damagePerGame: m['content.stats.metrics.damage_per_game'],
-		averageScore: m['content.stats.metrics.average_score']
+		winRate: m['content.stats.metrics.win_rate'](),
+		kdRatio: m['content.stats.metrics.kd_ratio'](),
+		killsPerGame: m['content.stats.metrics.kills_per_game'](),
+		deathsPerGame: m['content.stats.metrics.deaths_per_game'](),
+		survivalRate: m['content.stats.metrics.survival_rate'](),
+		assistsPerGame: m['content.stats.metrics.assists_per_game'](),
+		damagePerGame: m['content.stats.metrics.damage_per_game'](),
+		averageScore: m['content.stats.metrics.average_score']()
 	} as const);
 
 	let metricLabels = $derived([
-		metricText.winRate(),
-		metricText.kdRatio(),
+		metricText.winRate,
+		metricText.kdRatio,
 		metricText.killsPerGame,
 		metricText.survivalRate,
-		metricText.assistsPerGame(),
-		metricText.damagePerGame(),
-		metricText.averageScore()
+		metricText.assistsPerGame,
+		metricText.damagePerGame,
+		metricText.averageScore
 	]);
 
 	onMount(async () => {

--- a/src/routes/(user)/admin/edit-history/+page.ts
+++ b/src/routes/(user)/admin/edit-history/+page.ts
@@ -2,7 +2,7 @@ import { m } from '$lib/paraglide/messages';
 import type { PageMetadata } from '$lib/seo';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ data, url }) => {
+export const load: PageLoad = async ({ data }) => {
 	return {
 		...data,
 		page: data.page ? Number(data.page) : 1,


### PR DESCRIPTION
## Summary
Small unrelated fixes split out of a larger branch.

- **PlayerRadarGraph**: the metric label derivation referenced paraglide message *functions* instead of calling them. Invoke `m[...]()` so labels render as strings.
- **edit-history `load`**: remove an unused `url` destructure.

No functional change beyond the radar-label fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)