### PR TITLE
fix(security): stop logging password reset tokens and plaintext passwords

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -225,28 +225,20 @@ export async function generatePasswordResetToken(userId: string): Promise<string
 }
 
 export async function validatePasswordResetToken(token: string): Promise<string | null> {
-	console.info('[Auth] Validating password reset token:', token);
-
 	// Find the token in the database
 	const [tokenRecord] = await db
 		.select()
 		.from(table.passwordResetToken)
 		.where(eq(table.passwordResetToken.token, token));
 
-	console.info('[Auth] Token record found:', tokenRecord ? 'Yes' : 'No');
-
 	if (!tokenRecord) {
-		console.info('[Auth] No token record found in database');
+		console.info('[Auth] No password reset token record found');
 		return null;
 	}
 
-	console.info('[Auth] Token expires at:', tokenRecord.expiresAt);
-	console.info('[Auth] Current time:', new Date());
-	console.info('[Auth] Token expired:', Date.now() >= tokenRecord.expiresAt.getTime());
-
 	// Check if token is expired
 	if (Date.now() >= tokenRecord.expiresAt.getTime()) {
-		console.info('[Auth] Token is expired, cleaning up');
+		console.info('[Auth] Password reset token expired, cleaning up');
 		// Clean up expired token
 		await db
 			.delete(table.passwordResetToken)
@@ -254,7 +246,7 @@ export async function validatePasswordResetToken(token: string): Promise<string 
 		return null;
 	}
 
-	console.info('[Auth] Token is valid, returning userId:', tokenRecord.userId);
+	console.info('[Auth] Password reset token valid for user:', tokenRecord.userId);
 	return tokenRecord.userId;
 }
 

--- a/src/routes/(user)/reset-password/+page.server.ts
+++ b/src/routes/(user)/reset-password/+page.server.ts
@@ -11,14 +11,7 @@ import {
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
-	console.info('[Reset Password Load] URL:', url.toString());
-	console.info(
-		'[Reset Password Load] Search params:',
-		Object.fromEntries(url.searchParams.entries())
-	);
-
 	const encodedToken = url.searchParams.get('token');
-	console.info('[Reset Password Load] Encoded token:', encodedToken);
 
 	if (!encodedToken) {
 		console.info('[Reset Password Load] No token found in URL');
@@ -27,11 +20,9 @@ export const load: PageServerLoad = async ({ url }) => {
 
 	// Decode the URL-encoded token
 	const token = decodeURIComponent(encodedToken);
-	console.info('[Reset Password Load] Decoded token:', token);
 
 	// Validate the token
 	const userId = await validatePasswordResetToken(token);
-	console.info('[Reset Password Load] Validation result - userId:', userId);
 
 	if (!userId) {
 		console.info('[Reset Password Load] Token validation failed');
@@ -45,11 +36,6 @@ export const load: PageServerLoad = async ({ url }) => {
 export const actions: Actions = {
 	resetPassword: async (event) => {
 		console.info('[Reset Password Action] Attempting password reset');
-		console.info('[Reset Password Action] URL:', event.url.toString());
-		console.info(
-			'[Reset Password Action] Search params:',
-			Object.fromEntries(event.url.searchParams.entries())
-		);
 
 		const formData = await event.request.formData();
 		const data = {
@@ -57,8 +43,6 @@ export const actions: Actions = {
 			confirmPassword: formData.get('confirmPassword'),
 			token: formData.get('token')
 		};
-
-		console.info('[Reset Password Action] Form data:', data);
 
 		const result = RESET_PASSWORD_SCHEMA.safeParse(data);
 		if (!result.success) {
@@ -69,7 +53,6 @@ export const actions: Actions = {
 		}
 
 		const token = data.token as string;
-		console.info('[Reset Password Action] Token from form:', token);
 
 		if (!token) {
 			console.info('[Reset Password Action] No token found in form submission');


### PR DESCRIPTION
The password-reset flow wrote sensitive data into server logs on every request:

- `reset-password` load/action logged the full request URL and search params (which embed the reset token), the encoded and decoded token, and the entire form data object — **including the user's new plaintext password**.
- `validatePasswordResetToken` logged the raw token value.

Anyone with access to server/Vercel logs could read users' new passwords or capture valid reset tokens to hijack the reset flow. This removes the sensitive log lines, keeping only non-sensitive milestone logs.

Files: `src/routes/(user)/reset-password/+page.server.ts`, `src/lib/server/auth.ts`. No behavior change beyond logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)