### PR TITLE
i18n: add player_radar translations to all non-English locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -864,6 +864,10 @@
 		"banner_button": "Auf Ko‑fi unterstützen",
 		"banner_dismiss_title": "Vielleicht später"
 	},
+	"player_radar": {
+		"title": "Leistungsradar",
+		"dataset_performance": "Leistung"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -864,6 +864,10 @@
 		"banner_button": "Apoyar en Ko‑fi",
 		"banner_dismiss_title": "Quizás más tarde"
 	},
+	"player_radar": {
+		"title": "Radar de rendimiento",
+		"dataset_performance": "Rendimiento"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -864,6 +864,10 @@
 		"banner_button": "Soutenir sur Ko‑fi",
 		"banner_dismiss_title": "Peut‑être plus tard"
 	},
+	"player_radar": {
+		"title": "Radar de performance",
+		"dataset_performance": "Performance"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -858,6 +858,10 @@
 		"banner_button": "Dukung di Ko‑fi",
 		"banner_dismiss_title": "Nanti saja"
 	},
+	"player_radar": {
+		"title": "Radar performa",
+		"dataset_performance": "Performa"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -858,6 +858,10 @@
 		"banner_button": "Ko‑fi で支援する",
 		"banner_dismiss_title": "あとで考える"
 	},
+	"player_radar": {
+		"title": "パフォーマンスレーダー",
+		"dataset_performance": "パフォーマンス"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -858,6 +858,10 @@
 		"banner_button": "Ko‑fi에서 후원하기",
 		"banner_dismiss_title": "나중에 보기"
 	},
+	"player_radar": {
+		"title": "퍼포먼스 레이더",
+		"dataset_performance": "퍼포먼스"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/pt-br.json
+++ b/messages/pt-br.json
@@ -864,6 +864,10 @@
 		"banner_button": "Apoiar no Ko‑fi",
 		"banner_dismiss_title": "Talvez depois"
 	},
+	"player_radar": {
+		"title": "Radar de desempenho",
+		"dataset_performance": "Desempenho"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -876,6 +876,10 @@
 		"banner_button": "Поддержать на Ko‑fi",
 		"banner_dismiss_title": "Может позже"
 	},
+	"player_radar": {
+		"title": "Радар эффективности",
+		"dataset_performance": "Эффективность"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/uk-ua.json
+++ b/messages/uk-ua.json
@@ -876,6 +876,10 @@
 		"banner_button": "Підтримати на Ko‑fi",
 		"banner_dismiss_title": "Можливо пізніше"
 	},
+	"player_radar": {
+		"title": "Радар ефективності",
+		"dataset_performance": "Ефективність"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -858,6 +858,10 @@
 		"banner_button": "Ủng hộ trên Ko‑fi",
 		"banner_dismiss_title": "Để sau"
 	},
+	"player_radar": {
+		"title": "Radar hiệu suất",
+		"dataset_performance": "Hiệu suất"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/zh-tw.json
+++ b/messages/zh-tw.json
@@ -858,6 +858,10 @@
 		"banner_button": "在 Ko‑fi 支持",
 		"banner_dismiss_title": "之後再說"
 	},
+	"player_radar": {
+		"title": "表現雷達圖",
+		"dataset_performance": "表現"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -858,6 +858,10 @@
 		"banner_button": "在 Ko‑fi 支持",
 		"banner_dismiss_title": "以后再说"
 	},
+	"player_radar": {
+		"title": "表现雷达图",
+		"dataset_performance": "表现"
+	},
 	"mcp_tokens": "MCP Tokens",
 	"mcp_tokens_heading": "MCP Access Tokens",
 	"mcp_tokens_description": "Personal access tokens let you manage LemonTV data from an AI client through the authorized MCP server. Each token acts as you and every edit is attributed to your account. Treat tokens like passwords — they are shown only once.",


### PR DESCRIPTION
`bun run i18n:check` was failing — `player_radar.title` and `player_radar.dataset_performance` existed only in `en.json`. This adds translations for all 12 remaining locales. Check now passes; all JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)