### PR TITLE
chore: remove leftover debug console.log statements

### DIFF
--- a/src/routes/(content)/events/[id]/+page.server.ts
+++ b/src/routes/(content)/events/[id]/+page.server.ts
@@ -109,8 +109,6 @@ export const load: PageServerLoad = async ({ params }) => {
 			const slogans = byTeam[team.id];
 			const pick = slogans?.event?.[0] ?? slogans?.general?.[0];
 
-			console.log('[Slogans] Slogans', slogans);
-			console.log('[Slogans] Pick', pick);
 			return {
 				...team,
 				logoURL: imageUrlMap.get(team.logo || '') || team.logo,

--- a/src/routes/(content)/events/[id]/EventTeamCard.svelte
+++ b/src/routes/(content)/events/[id]/EventTeamCard.svelte
@@ -48,8 +48,6 @@
 	const startersCount = $derived(participant?.main?.filter(Boolean).length ?? 0);
 	const subsCount = $derived(participant?.reserve?.filter(Boolean).length ?? 0);
 	const coachesCount = $derived(participant?.coach?.filter(Boolean).length ?? 0);
-
-	console.log('[Slogans] Participant', participant);
 </script>
 
 {#snippet playerLink(player: { name: string; slug: string; nationalities: string[] })}

--- a/src/routes/(content)/players/(tables)/+page.server.ts
+++ b/src/routes/(content)/players/(tables)/+page.server.ts
@@ -54,16 +54,6 @@ export const load: PageServerLoad = async ({ url }) => {
 	const offset = (page - 1) * pageSize;
 	const limit = pageSize;
 
-	console.log(`[Players] Loading players with conditions:`, {
-		search,
-		nationalities,
-		page,
-		pageSize,
-		sortBy,
-		offset,
-		limit
-	});
-
 	// -- Dynamic Query Conditions --
 	const whereConditions = [
 		search.length > 0 ? like(table.player.name, `%${search}%`) : undefined,
@@ -71,8 +61,6 @@ export const load: PageServerLoad = async ({ url }) => {
 			? inArray(table.player.nationality, nationalities as TCountryCode[])
 			: undefined
 	].filter((x): x is NonNullable<typeof x> => x !== undefined);
-
-	console.log(`[Players] Where conditions:`, whereConditions);
 
 	const orderByConditions = [
 		sortBy === 'name-abc'
@@ -118,16 +106,12 @@ export const load: PageServerLoad = async ({ url }) => {
 		.select({ cnt: sql<number>`count(distinct ${table.player.id})` })
 		.from(table.player);
 
-	console.log(`[Players] Total players:`, totalPlayers.length);
-
 	// -- 1. Get total count with filters applied --
 	const [{ cnt: totalCount }] = await db
 		.select({ cnt: sql<number>`count(distinct ${table.player.id})` })
 		.from(table.player)
 		.leftJoin(table.playerStats, eq(table.player.id, table.playerStats.playerId))
 		.where(and(...whereConditions));
-
-	console.log(`[Players] Total count:`, totalCount);
 
 	// -- 2. Get the sorted and paginated list of player IDs --
 	const playerIdsQuery = await db

--- a/src/routes/(content)/players/[id]/+page.server.ts
+++ b/src/routes/(content)/players/[id]/+page.server.ts
@@ -53,11 +53,6 @@ export const load: PageServerLoad = async ({ params, locals: { user } }) => {
 		}))
 	}));
 
-	console.log(
-		`[players/[id]] playerDetailedMatches`,
-		JSON.stringify(playerDetailedMatches, null, 2)
-	);
-
 	// Create a teams Map using team names/abbreviations as keys
 	// This is what the MatchCard component expects
 	const teamsMap = new Map<string, any>();

--- a/src/routes/(content)/players/[id]/PlayerNetWLGraph.svelte
+++ b/src/routes/(content)/players/[id]/PlayerNetWLGraph.svelte
@@ -227,12 +227,8 @@
 	// Generate data from real match history only
 	function generateNetWLData() {
 		if (!playerMatches || playerMatches.length === 0) {
-			console.log('No matches available, returning empty data');
 			return [];
 		}
-
-		// Use real match history data
-		console.log('Using real match history:', playerMatches.length, 'matches');
 
 		const sortedMatches = [...playerMatches].sort((a, b) => {
 			const dateA = new Date(a.event.date).getTime();
@@ -263,7 +259,6 @@
 			}
 		}
 
-		console.log('Generated real data (game-based):', data);
 		return data;
 	}
 

--- a/src/routes/(content)/teams/[id]/+page.server.ts
+++ b/src/routes/(content)/teams/[id]/+page.server.ts
@@ -47,7 +47,6 @@ export const load: PageServerLoad = async ({ params, locals: { user } }) => {
 
 	// Get detailed match data for the team
 	const teamDetailedMatches = await getTeamDetailedMatches(team.id);
-	console.log(`[teams/[id]] teamDetailedMatches`, teamDetailedMatches);
 
 	// Transform match data to include team objects
 	const transformedMatches = teamDetailedMatches.map((match) => ({

--- a/src/routes/(user)/admin/events/subforms/EventTeamPlayersInput.svelte
+++ b/src/routes/(user)/admin/events/subforms/EventTeamPlayersInput.svelte
@@ -138,12 +138,6 @@
 
 	function addTeam(teamId: string) {
 		if (!selectedTeams.includes(teamId)) {
-			console.log(
-				'[EventTeamPlayersInput] Adding team:',
-				teamId,
-				'Current selectedTeams:',
-				selectedTeams
-			);
 			selectedTeams = [...selectedTeams, teamId];
 			// Ensure meta defaults exist
 			if (!eventTeams.some((et) => et.teamId === teamId)) {


### PR DESCRIPTION
Removes development-only `console.log` calls that ran on production page loads and dumped request params and full match/participant data into logs (notably `players/[id]` logged a pretty-printed `JSON.stringify` of every detailed match per request). Intentional structured `console.info` logging is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)