### PR TITLE
feat(mcp): add update_team and update_player tools

### DIFF
--- a/src/lib/server/data/players.ts
+++ b/src/lib/server/data/players.ts
@@ -1206,6 +1206,100 @@ export async function createPlayer(
 	return id;
 }
 
+export interface UpdatePlayerFields {
+	name?: string;
+	slug?: string;
+	avatar?: string | null;
+	/** Full replacement of nationalities; first is primary, rest are additional. */
+	nationalities?: string[];
+}
+
+/**
+ * Partial update of a player's scalar fields and (optionally) nationalities.
+ * Only the fields you pass are changed, and it never touches aliases / game
+ * accounts / social accounts (unlike the full `updatePlayer`, which replaces
+ * those collections). When `nationalities` is given it fully replaces the
+ * primary nationality and the additional-nationality rows. Records an
+ * `edit_history` row per changed field; returns the changed field names.
+ */
+export async function updatePlayerFields(
+	id: string,
+	fields: UpdatePlayerFields,
+	editedBy: string
+): Promise<{ changed: string[] }> {
+	return await db.transaction(async (tx) => {
+		const [current] = await tx.select().from(player).where(eq(player.id, id));
+		if (!current) throw new Error(`Player not found: ${id}`);
+
+		const set: Record<string, unknown> = {};
+		const changed: string[] = [];
+
+		const recordChange = (field: string, before: unknown, after: unknown) => {
+			changed.push(field);
+			return tx.insert(editHistory).values({
+				id: randomUUID(),
+				tableName: 'player',
+				recordId: id,
+				fieldName: field,
+				oldValue: before === null || before === undefined ? null : String(before),
+				newValue: after === null || after === undefined ? null : String(after),
+				editedBy
+			});
+		};
+
+		for (const key of ['name', 'slug', 'avatar'] as const) {
+			const next = fields[key];
+			if (next === undefined) continue;
+			const before = (current as Record<string, unknown>)[key] ?? null;
+			const after = next ?? null;
+			if (before === after) continue;
+			set[key] = after;
+			await recordChange(key, before, after);
+		}
+
+		if (fields.nationalities !== undefined) {
+			const list = fields.nationalities;
+			const primary = (list[0] ?? null) as TCountryCode | null;
+			if ((current.nationality ?? null) !== (primary ?? null)) {
+				set.nationality = primary;
+				await recordChange('nationality', current.nationality ?? null, primary);
+			}
+
+			const currentAdditional = await tx
+				.select()
+				.from(playerAdditionalNationality)
+				.where(eq(playerAdditionalNationality.playerId, id));
+			const oldAdditional = currentAdditional.map((a) => a.nationality);
+			const newAdditional = list.slice(1);
+
+			if (JSON.stringify(oldAdditional) !== JSON.stringify(newAdditional)) {
+				await tx
+					.delete(playerAdditionalNationality)
+					.where(eq(playerAdditionalNationality.playerId, id));
+				if (newAdditional.length > 0) {
+					await tx.insert(playerAdditionalNationality).values(
+						newAdditional.map((nationality) => ({
+							playerId: id,
+							nationality: nationality as TCountryCode
+						}))
+					);
+				}
+				await recordChange(
+					'additionalNationalities',
+					oldAdditional.join(',') || null,
+					newAdditional.join(',') || null
+				);
+			}
+		}
+
+		if (Object.keys(set).length > 0) {
+			await tx.update(player).set(set).where(eq(player.id, id));
+		}
+
+		return { changed };
+	});
+}
+
 export async function updatePlayer(
 	data: { id: string } & Partial<Omit<Player, 'gameAccounts'>> & {
 			gameAccounts: Player['gameAccounts'];

--- a/src/lib/server/data/teams.ts
+++ b/src/lib/server/data/teams.ts
@@ -931,6 +931,62 @@ export async function createTeam(
 	return id;
 }
 
+export interface UpdateTeamFields {
+	name?: string;
+	slug?: string;
+	abbr?: string | null;
+	logo?: string | null;
+	region?: Region | null;
+}
+
+/**
+ * Partial scalar update of a team — only the fields you pass are changed, and it
+ * NEVER touches aliases/roster/slogans. (The full `updateTeam` deletes and
+ * re-inserts those collections, so calling it with a partial payload would wipe
+ * them.) Records one `edit_history` row per actually-changed field and returns
+ * the list of changed field names.
+ */
+export async function updateTeamFields(
+	id: string,
+	fields: UpdateTeamFields,
+	editedBy: string
+): Promise<{ changed: string[] }> {
+	return await db.transaction(async (tx) => {
+		const [current] = await tx.select().from(table.team).where(eq(table.team.id, id));
+		if (!current) throw new Error(`Team not found: ${id}`);
+
+		const columns: (keyof UpdateTeamFields)[] = ['name', 'slug', 'abbr', 'logo', 'region'];
+		const set: Record<string, unknown> = {};
+		const changed: string[] = [];
+
+		for (const key of columns) {
+			const next = fields[key];
+			if (next === undefined) continue;
+			const before = (current as Record<string, unknown>)[key] ?? null;
+			const after = next ?? null;
+			if (before === after) continue;
+			set[key] = after;
+			changed.push(key);
+			await tx.insert(editHistory).values({
+				id: randomUUID(),
+				tableName: 'team',
+				recordId: id,
+				fieldName: key,
+				oldValue: before === null ? null : String(before),
+				newValue: after === null ? null : String(after),
+				editedBy
+			});
+		}
+
+		if (changed.length > 0) {
+			set.updatedAt = new Date().toISOString();
+			await tx.update(table.team).set(set).where(eq(table.team.id, id));
+		}
+
+		return { changed };
+	});
+}
+
 export async function updateTeam(
 	data: {
 		id: string;

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -31,8 +31,20 @@ import {
 	EVENT_TEAM_PLAYER_ROLES,
 	EVENT_CASTER_ROLES
 } from './event-args';
-import { createPlayer, getPlayer, getPlayers } from '$lib/server/data/players';
-import { createTeam, getTeam, getTeams } from '$lib/server/data/teams';
+import {
+	createPlayer,
+	getPlayer,
+	getPlayers,
+	updatePlayerFields,
+	type UpdatePlayerFields
+} from '$lib/server/data/players';
+import {
+	createTeam,
+	getTeam,
+	getTeams,
+	updateTeamFields,
+	type UpdateTeamFields
+} from '$lib/server/data/teams';
 import { getGameAccountServer } from '$lib/data/players';
 import { formatSlug } from '$lib/utils/strings';
 import type { McpTool } from './dispatch';
@@ -86,6 +98,28 @@ async function assertTeamsExist(teamIds: string[]): Promise<void> {
 			`Unknown team id(s): ${missing.join(', ')} (create them with create_team first)`
 		);
 	}
+}
+
+/** Resolve a team id-or-slug to its id, throwing a clear error if unknown. */
+async function resolveTeamId(idOrSlug: string): Promise<string> {
+	const [row] = await db
+		.select({ id: table.team.id })
+		.from(table.team)
+		.where(or(eq(table.team.id, idOrSlug), eq(table.team.slug, idOrSlug)))
+		.limit(1);
+	if (!row) throw new Error(`Team not found: ${idOrSlug}`);
+	return row.id;
+}
+
+/** Resolve a player id-or-slug to its id, throwing a clear error if unknown. */
+async function resolvePlayerId(idOrSlug: string): Promise<string> {
+	const [row] = await db
+		.select({ id: table.player.id })
+		.from(table.player)
+		.where(or(eq(table.player.id, idOrSlug), eq(table.player.slug, idOrSlug)))
+		.limit(1);
+	if (!row) throw new Error(`Player not found: ${idOrSlug}`);
+	return row.id;
 }
 
 /** Verify every player id exists before writing rows that reference them. */
@@ -770,6 +804,77 @@ export const TOOLS: McpTool[] = [
 				identity.userId
 			);
 			return { id, slug, created: true };
+		}
+	},
+	{
+		name: 'update_team',
+		description:
+			'Update scalar fields of an existing team (by id or slug): name, slug, abbr, logo, region. Partial — only the fields you pass change, and it never touches the roster, aliases, or slogans (use the admin UI for those). Returns which fields changed. Attributed to the token owner.',
+		requiresWrite: true,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				idOrSlug: { type: 'string', description: 'The team id or slug to update.' },
+				name: { type: 'string', description: 'New display name.' },
+				slug: { type: 'string', description: 'New URL slug (lowercase-kebab, unique).' },
+				abbr: { type: 'string', description: 'Short tag, e.g. "DRG".' },
+				logo: { type: 'string', description: 'Logo image URL/key.' },
+				region: { type: 'string', enum: [...TEAM_REGIONS], description: 'Team region.' }
+			},
+			required: ['idOrSlug'],
+			additionalProperties: false
+		},
+		handler: async (args, identity) => {
+			const teamId = await resolveTeamId(requireString(args, 'idOrSlug'));
+			const fields: UpdateTeamFields = {};
+			if (args.name !== undefined) fields.name = requireString(args, 'name');
+			if (args.slug !== undefined) fields.slug = formatSlug(requireString(args, 'slug'));
+			if (args.abbr !== undefined) fields.abbr = requireString(args, 'abbr');
+			if (args.logo !== undefined) fields.logo = requireString(args, 'logo');
+			if (args.region !== undefined)
+				fields.region = requireEnum(args.region, TEAM_REGIONS, 'region');
+			const { changed } = await updateTeamFields(teamId, fields, identity.userId);
+			return { id: teamId, changed, updated: changed.length > 0 };
+		}
+	},
+	{
+		name: 'update_player',
+		description:
+			'Update an existing player (by id or slug): name, slug, avatar, and/or nationalities. Partial — only the fields you pass change; it never touches aliases, game accounts, or social accounts (use the admin UI for those). Passing nationalities fully replaces them (first = primary). Returns which fields changed. Attributed to the token owner.',
+		requiresWrite: true,
+		inputSchema: {
+			type: 'object',
+			properties: {
+				idOrSlug: { type: 'string', description: 'The player id or slug to update.' },
+				name: { type: 'string', description: 'New display name.' },
+				slug: { type: 'string', description: 'New URL slug.' },
+				avatar: { type: 'string', description: 'Avatar image URL/key.' },
+				nationalities: {
+					type: 'array',
+					items: { type: 'string' },
+					description: 'ISO country codes; first is primary. Replaces all nationalities.'
+				}
+			},
+			required: ['idOrSlug'],
+			additionalProperties: false
+		},
+		handler: async (args, identity) => {
+			const playerId = await resolvePlayerId(requireString(args, 'idOrSlug'));
+			const fields: UpdatePlayerFields = {};
+			if (args.name !== undefined) fields.name = requireString(args, 'name');
+			if (args.slug !== undefined) fields.slug = formatSlug(requireString(args, 'slug'));
+			if (args.avatar !== undefined) fields.avatar = requireString(args, 'avatar');
+			if (args.nationalities !== undefined) {
+				if (!Array.isArray(args.nationalities)) throw new Error('nationalities must be an array');
+				const list = args.nationalities
+					.map((n) => (typeof n === 'string' ? n.trim().toUpperCase() : ''))
+					.filter((n) => n !== '');
+				if (new Set(list).size !== list.length)
+					throw new Error('nationalities contains duplicates');
+				fields.nationalities = list;
+			}
+			const { changed } = await updatePlayerFields(playerId, fields, identity.userId);
+			return { id: playerId, changed, updated: changed.length > 0 };
 		}
 	}
 ];


### PR DESCRIPTION
**Stacked on #84** (event participant/result tools) — review/merge that first.

Adds partial-update MCP tools so existing teams/players can be corrected or enriched (fixing slugs, filling the ~60% of players missing a nationality) — previously the server could only create them.

- **update_team** — scalar fields (name/slug/abbr/logo/region).
- **update_player** — name/slug/avatar and full-replace nationalities.

Both are backed by **new dedicated data-layer functions** (`updateTeamFields` / `updatePlayerFields`) that only touch scalar columns and record per-field `edit_history`. This deliberately avoids the existing `updateTeam`/`updatePlayer`, which delete-and-reinsert aliases/roster/slogans/game-accounts and would **wipe** those collections on a partial call.

70 MCP tests pass, 0 type errors, no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)